### PR TITLE
Simplified category theory using setoid rewrite

### DIFF
--- a/theories/algcat.v
+++ b/theories/algcat.v
@@ -1,4 +1,182 @@
-(* Copyright (C) 2024-2026 Florent Hivert, license: LGPL-3-or-later *)
+(** * Cat.algcat : Algebraic Categories *)
+(******************************************************************************)
+(*    Copyright (C) 2019-2026 Florent Hivert <florent.hivert@lisn.fr>         *)
+(*                                                                            *)
+(*    This program is free software; you can redistribute it and/or           *)
+(*    modify it under the terms of the GNU Lesser General Public              *)
+(*    License as published by the Free Software Foundation; either            *)
+(*    version 3 of the License, or (at your option) any later version.        *)
+(*                                                                            *)
+(*    This code is distributed in the hope that it will be useful,            *)
+(*    but WITHOUT ANY WARRANTY; without even the implied warranty of          *)
+(*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU       *)
+(*    General Public License for more details.                                *)
+(*                                                                            *)
+(*    The full text of the LGPL is available at:                              *)
+(*                                                                            *)
+(*                  http://www.gnu.org/licenses/                              *)
+(******************************************************************************)
+(** #
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+ # *)
+(** * Algebraic categories
+
+We define the following categories:
+
+- Sets         == the category of Sets (modeled by choiceType in MC)
+                  There is a coercion {hom[Sets] a -> b} >-> (a -> b)
+- NModules     == the category of N-modules. There is a coercion
+                  {hom[NModules] a -> b} >-> {additive a -> b}
+- ZModules     == the category of Z-modules. There is a coercion
+                  {hom[ZModules] a -> b} >-> {additive a -> b}
+- Monoids      == the category of multiplicative monoids.
+                  There is a coercion
+                  {hom[Monoids] a -> b} >-> {mmorphism a -> b}
+- ComMonoids   == the category of commutative multiplicative monoids.
+                  There is a coercion
+                  {hom[ComMonoids] a -> b} >-> {mmorphism a -> b}
+- SemiRings    == the category of non-zero semi-rings. There is a coercion
+                  {hom[SemiRings] a -> b} >-> {rmorphism a -> b}
+- Rings        == the category of non-zero rings. There is a coercion
+                  {hom[Rings] a -> b} >-> {rmorphism a -> b}
+- ComSemiRings == the category of non-zero commutative semi-rings.
+                  There is a coercion
+                  {hom[ComSemiRings] a -> b} >-> {rmorphism a -> b}
+- ComRings     == the category of non-zero commutative rings.
+                  There is a coercion
+                  {hom[ComRings] a -> b} >-> {rmorphism a -> b}
+- LModules R   == the category of left R-module where R : nzRingType
+                  There is a coercion
+                  {hom[LModules R] a -> b} >-> {linear a -> b}
+- LAlgebras R  == the category of left R-algebra where R : nzRingType
+                  There is a coercion
+                  {hom[LAlgebras R] a -> b} >-> {lrmorphism a -> b}
+- Algebras R   == the category of R-algebra where R : nzRingType
+                  There is a coercion
+                  {hom[Algebras R] a -> b} >-> {lrmorphism a -> b}
+- ComAlgebras R == the category of commutative R-algebra where R : nzRingType
+                  There is a coercion
+                  {hom[ComAlgebras R] a -> b} >-> {lrmorphism a -> b}
+
+We define the following forgetful functors, we use following the consistent
+naming scheme: forget_CatSource_to_CatTarget for example
+forget_NModules_to_Sets. Moreover in the following R is a nzRingType.
+
+- NModules -> Sets
+- ZModules -> Sets
+- ZModules -> NModules
+- Monoids -> Sets
+- ComMonoids -> Sets
+- ComMonoids -> Monoids
+- SemiRings -> Sets
+- SemiRings -> NModules
+- Rings -> Sets
+- Rings -> ZModules
+- Rings -> SemiRings
+- ComSemiRings -> Sets
+- ComSemiRings -> SemiRings
+- ComRings -> Sets
+- ComRings -> ComSemiRings
+- ComRings -> Rings
+- LModules R -> Sets
+- LModules R -> ZModules
+- LAlgebras R -> Sets
+- LAlgebras R -> Rings
+- LAlgebras R -> LModules R
+- Algebras R -> Sets
+- Algebras R -> Monoids
+- Algebras R -> LAlgebras R
+- ComAlgebras R -> Sets
+- ComAlgebras R -> ComRings
+- ComAlgebras R -> ComMonoids
+- ComAlgebras R -> Algebras R
+
+Adjunction of functors:
+
+- FreeNModule  == the left adjoint functor of forget_NModules_to_Sets
+                  as witnessed by adjoint_FreeNModule_forget_to_Sets.
+  {freenmod A} == the image of A by FreeNModule
+  univmap_FreeNModule f == for any function f in {hom[Sets] A -> M}
+                  the universal morphism in {hom[NModules] {freenmod A} -> M}
+
+- FreeMonoid   == the left adjoint functor of forget_Monoids_to_Sets as
+                  witnessed by adjoint_FreeMonoid_forget_to_Sets.
+  {freemon A}  == the image of A by FreeMonoid.
+  univmap_FreeMonoid f == for any function f in {hom[Sets] A -> M}
+                  the universal morphism in {hom[Monoids] {freemon A} -> M}
+
+- FreeComMonoid == the left adjoint functor of forget_ComMonoids_to_Sets
+                  as witnessed by adjoint_FreeComMonoid_forget_to_Sets.
+  {freecmon A} == the image of A by FreeComMonoid
+  univmap_FreeComMonoid f == for any function f in {hom[Sets] A -> M}
+                  the universal morphism in
+                  {hom[ComMonoids] {freecmon A} -> M}
+
+- FreeLModule R == (R in Rings), the left adjoint functor of
+                  forget_LModules_to_Sets as witnessed by
+                  adjoint_FreeLModule_forget_to_Sets R
+  {freelmod R[A]} == the image of A by FreeLmodule R
+  univmap_FreeLModule R f == for any function f in {hom[Sets] A -> M}
+                  where M : LModules R the universal morphism in
+                  {hom[LModules R] {freelmod R[A]} -> M}
+  homRing_FreeLModule A f == the functorial map from {freemod R[A]} to
+                  {freemod S[A]} where A : Sets and f : {rmorphism R -> S}
+
+- MonoidAlgebra R == (R in ComRings), the left adjoint functor of
+                  forget_Algebras_to_Monoids as witnessed by
+                  adjoint_MonoidAlgebra_forget_to_Monoids R
+  {monalg R[A]} == the image of A by MonoidAlgebra R
+  univmap_MonoidAlgebra A f == for any morphism in {hom[Monoids] M -> A}
+                  where A : Algebras R the universal morphism in
+                  {hom[Algebra R] {monalg R[A]} -> M}
+  homRing_MonoidAlgebra A f == where A : Monoids and f : {rmorphism R -> S}
+                  the functorial map from {monalg R[A]} to {monalg S[A]}
+
+- FreeAlgebra R == (R in ComRings), the left adjoint functor of
+                  forget_Algebras_to_Sets as witnessed by
+                  adjoint_FreeAlgebra_forget_to_Sets R
+  {freealg R[A]} == the image of A by FreeAlgebra R
+  univmap_FreeAlgebra R f == for any function f in {hom[Sets] E -> A}
+                  the universal morphism in
+                  {hom[Algebra R] {freealg R[E]} -> A}
+  homRing_FreeAlgebra E f == where E : Sets and f : {rmorphism R -> S}
+                  the functorial map from {freealg R[E]} to {freealg S[E]}
+
+- ComMonoidAlgebra R == (R in ComRings), the left adjoint functor of
+                  forget_ComAlgebras_to_ComMonoids as witnessed by
+                  adjoint_ComMonoidAlgebra_forget_to_ComMonoids R
+  {monalg R[M]} == the image of M by ComMonoidAlgebra R -- when M is a
+                  commutative monoid, automatically a commutative algebra
+  univmap_ComMonoidAlgebra R f == for any morphism f in
+                  {hom[ComMonoids] M -> forget_ComAlgebras_to_ComMonoids A}
+                  the universal morphism in
+                  {hom[ComAlgebra R] {monalg R[M]} -> A}
+  homRing_ComMonoidAlgebra M f == where M : ComMonoids and f : {rmorphism R -> S}
+                  the functorial map from {monalg R[M]} to {monalg S[M]}
+
+- FreeComAlgebra R == (R in ComRings), the left adjoint functor of
+                  forget_Algebras_to_Sets as witnessed by
+                  adjoint_FreeComAlgebra_forget_to_Sets R
+  {freecalg R[A]} == the image of A by FreeComAlgebra R
+  univmap_FreeComAlgebra R f == for any function f in {hom[Sets] E -> A}
+                  where A : ComAlgebras R the universal morphism in
+                  {hom[Algebra R] {freecalg R[E]} -> A}
+  homRing_FreeComAlgebra A f == where E : Sets and f : {rmorphism R -> S}
+                  the functorial map from {freecalg R[E]} to {freecalg S[E]}
+
+
+Equivalence of categories:
+
+- equivalence_ComMonoids_NModules : through the functors
+  NMod_of_ComMonoid and ComMonoid_of_NMod
+
+Finaly the following useful notion are defined:
+
+- setHom f     == the Sets morphism associated to the function f.
+
+
+*)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
 From mathcomp Require Import choice fintype finfun bigop.
@@ -42,7 +220,8 @@ HB.instance Definition _ :=
   isCategory.Build nmodType (fun T : nmodType => T)
     nmod_morphism idfun_is_nmod_morphism comp_is_nmod_morphism.
 Definition NModules : category := nmodType.
-Definition additive_of_Nmod a b (f : {hom[NModules] a -> b}) :
+#[warning="-uniform-inheritance"]
+Coercion additive_of_Nmod a b (f : {hom[NModules] a -> b}) :
   {additive a -> b} :=
   HB.pack (Hom.sort f) (GRing.isNmodMorphism.Build _ _ _ (isHom_inhom f)).
 Lemma additive_of_NmodE a b (f : {hom[NModules] a -> b}) :
@@ -471,8 +650,8 @@ Notation forget_LAlgebras_to_LModules := ForgetLAlgebras_to_LModules.functor.
 Lemma forget_LAlgebras_to_LModulesE R a b (f : {hom[LAlgebras R] a -> b}) :
   forget_LAlgebras_to_LModules R # f = f :> (_ -> _).
 Proof. by []. Qed.
-Definition forget_LAlgebras_to_Sets (R : nzRingType) :=
-  (forget_LModules_to_Sets R) \O (forget_LAlgebras_to_LModules R).
+Definition forget_LAlgebras_to_Sets R :=
+  forget_LModules_to_Sets R \O forget_LAlgebras_to_LModules R.
 Lemma forget_LAlgebras_to_SetsE R a b (f : {hom[LAlgebras R] a -> b}) :
   forget_LAlgebras_to_Sets R # f = f :> (_ -> _).
 Proof. by []. Qed.
@@ -633,7 +812,8 @@ Definition functor R : {functor ComAlgebras R -> ComRings} := @forget R.
 
 End ForgetComAlgebras_to_ComRings.
 
-Definition forget_ComAlgebras_to_ComRings := ForgetComAlgebras_to_ComRings.functor.
+Notation forget_ComAlgebras_to_ComRings :=
+  ForgetComAlgebras_to_ComRings.functor.
 Lemma forget_ComAlgebras_to_ComRingsE R a b (f : {hom[ComAlgebras R] a -> b}) :
   forget_ComAlgebras_to_ComRings R # f = f :> (_ -> _).
 Proof. by []. Qed.
@@ -1156,7 +1336,7 @@ Notation adjoint_NModule_ComMonoid := ComMonoids_NModules_Adjoints.compMC.
 
 (* TODO: Those are full subcategories, devise some infrastructure to
    - handle trivial forgetful functors
-   - morphisms coercions. *)
+   - morphisms coercions.
 HB.instance Definition _ :=
   isCategory.Build unitRingType (fun T : unitRingType => T)
     semiring_morph idfun_is_semiring_morph comp_is_semiring_morph.
@@ -1178,7 +1358,7 @@ HB.instance Definition _ (R : nzRingType) :=
     (fun a b (f : a -> b) => lalg_morphism f)
     (@idfun_is_lalg_morphism R) (@comp_is_lalg_morphism R).
 Definition ComUnitAlgebras (R : nzRingType) : category := comUnitAlgType R.
-
+ *)
 
 Local Open Scope ring_scope.
 Local Open Scope mset_scope.
@@ -1244,6 +1424,8 @@ HB.instance Definition _ :=
   @isFunctor.Build Sets NModules
     FreeNModule FreeNModule_mor FreeNModule_ext FreeNModule_id FreeNModule_comp.
 
+Notation "{ 'freenmod' T }" := (FreeNModule T)
+                                (at level 0, format "{ 'freenmod'  T }").
 
 Module FreeNModuleAdjoint.
 Section Adjoint.
@@ -1306,12 +1488,13 @@ Variables (A : Sets) (M : NModules) (f : {hom[Sets] A -> M}).
 
 Let Adj := adjoint_FreeNModule_forget_to_Sets.
 
-Definition univmap_FreeNModule := AdjointFunctors.hom_inv Adj f.
+Definition univmap_FreeNModule : {hom[NModules] {freenmod A} -> M}
+  := AdjointFunctors.hom_inv Adj f.
 
 Lemma univmap_FreeNModuleP a : univmap_FreeNModule [mset a] = f a.
 Proof. exact: (AdjointFunctors.hom_invK Adj). Qed.
 
-Lemma univmap_FreeNModule_uniq (g : {hom[NModules] {mset A} -> M}) :
+Lemma univmap_FreeNModule_uniq (g : {hom[NModules] {freenmod A} -> M}) :
   (forall a : A, g [mset a] = f a) -> g =m= univmap_FreeNModule.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
@@ -1444,12 +1627,18 @@ Local Close Scope monoid_scope.
 Local Open Scope ring_scope.
 
 (** Adjunction free L-Modules -| forget L-Modules to Sets and *)
+Definition FreeLModuleT (R : Rings) (a : Sets) := {freemod R[a]}.
+HB.instance Definition _ (R : Rings) (a : Sets) :=
+  GRing.Lmodule.copy (FreeLModuleT R a) {freemod R[a]}.
+Notation "{ 'freelmod' R [ T ] }" := (FreeLModuleT R T)
+  (at level 0, format "{ 'freelmod'  R [ T ] }").
+
 Section Set_to_FreeLmodule.
 
 Variable R : nzRingType.
 
 Lemma FreeLModuleE (a : Sets) (T : LModules R)
-  (f g : {hom[LModules R] {freemod R[a]} -> T}) :
+  (f g : {hom[LModules R] {freelmod R[a]} -> T}) :
   (forall x : a, f [fm / x |-> 1] = g [fm / x |-> 1]) -> f =m= g.
 Proof.
 move=> eq x; rewrite -(linear_of_LmodE f) -(linear_of_LmodE g).
@@ -1457,7 +1646,7 @@ exact: linear_fmE.
 Qed.
 
 Variable (a b : Sets) (f : {hom[Sets] a -> b}).
-Definition hom_flm (m : {freemod R[a]}) : {freemod R[b]} :=
+Definition hom_flm (m : {freelmod R[a]}) : {freelmod R[b]} :=
   \sum_(i <- finsupp m) [fm / f i |-> m i].
 
 Lemma hom_flm1 (x : a) : hom_flm [fm / x |-> 1] = [fm / f x |-> 1].
@@ -1479,21 +1668,23 @@ rewrite -!(finsupp_widen _ (S := finsupp m `|` finsupp n)%fset) /=.
   by rewrite mulr0 addr0.
 Qed.
 HB.instance Definition _ :=
-  GRing.isLinear.Build R {freemod R[a]} {freemod R[b]} _ hom_flm hom_flm_linear.
+  GRing.isLinear.Build
+    R {freelmod R[a]} {freelmod R[b]} _ hom_flm hom_flm_linear.
 
 Lemma hom_flmc (x : a) (c : R) : hom_flm [fm / x |-> c] = [fm / f x |-> c].
 Proof. by rewrite -fm1ZE linearZ /= hom_flm1 fm1ZE. Qed.
 
 End Set_to_FreeLmodule.
 
+
 Section Functor.
 Variable (R : nzRingType).
 
 HB.instance Definition _ (a b : Sets) (f : {hom[Sets] a -> b}) :=
-  @isHom.Build (LModules R) {freemod R[a]} {freemod R[b]}
+  @isHom.Build (LModules R) {freelmod R[a]} {freelmod R[b]}
     (hom_flm f : (_ : LModules R) -> _) (hom_flm_linear f).
 Definition FreeLModule_mor (a b : Sets) (f : {hom[Sets] a -> b})
-  : {hom[LModules R] {freemod R[a]} -> {freemod R[b]}} := hom_flm f.
+  : {hom[LModules R] {freelmod R[a]} -> {freelmod R[b]}} := hom_flm f.
 
 Fact FreeLModule_ext : FunctorLaws.ext FreeLModule_mor.
 Proof.
@@ -1513,12 +1704,14 @@ rewrite -!linear_of_LmodE; apply: linear_fmE => /= x.
 by rewrite /hom_flm /= !(finsupp_fm1, big_seq_fset1, fm1E, eqxx).
 Qed.
 
-Definition FreeLModule a : LModules R := {freemod R[a]}.
+Definition FreeLModule_functor a : LModules R := {freelmod R[a]}.
 HB.instance Definition _ :=
-  @isFunctor.Build Sets (LModules R) FreeLModule
+  @isFunctor.Build Sets (LModules R) FreeLModule_functor
      FreeLModule_mor FreeLModule_ext FreeLModule_id FreeLModule_comp.
 
 End Functor.
+Definition FreeLModule (R : Rings) : {functor Sets -> LModules R}
+  := FreeLModule_functor R.
 
 
 Module FreeLModuleAdjoint.
@@ -1528,7 +1721,7 @@ Variable R : nzRingType.
 Implicit Types (a : Sets) (T : LModules R).
 Local Notation fm := (@FreeLModule R).
 Local Notation forgetf := (forget_LModules_to_Sets R).
-Definition eta_fun a (x : a) : {freemod R[a]} := [fm / x |-> 1].
+Definition eta_fun a (x : a) : {freelmod R[a]} := [fm / x |-> 1].
 Definition eta : FId ~~> forgetf \o fm := eta_fun.
 Fact eta_natural : naturality FId (forgetf \o fm) eta.
 Proof. by move=> /= a b h x /=; rewrite /eta_fun FIdf hom_flm1. Qed.
@@ -1536,7 +1729,7 @@ HB.instance Definition _ :=
   @isNatural.Build Sets Sets FId (forgetf \o fm) eta eta_natural.
 
 Definition eps_fun T (m : (fm \o forgetf) T) : T :=
-      \sum_(i <- finsupp (m : {freemod R[_]})) (m i) *: i.
+      \sum_(i <- finsupp (m : {freelmod R[_]})) (m i) *: i.
 Fact eps_fun_linear T : linear (@eps_fun T).
 Proof.
 rewrite /eps_fun => c s t; rewrite scaler_sumr.
@@ -1597,12 +1790,13 @@ Variables (A : Sets) (M : LModules R) (f : {hom[Sets] A -> M}).
 
 Let Adj := (adjoint_FreeLModule_forget_to_Sets R).
 
-Definition univmap_FreeLModule := AdjointFunctors.hom_inv Adj f.
+Definition univmap_FreeLModule : {hom[LModules R] {freelmod R[A]} -> M} :=
+  AdjointFunctors.hom_inv Adj f.
 
 Lemma univmap_FreeLModuleP a : univmap_FreeLModule [fm / a |-> 1] = f a.
 Proof. by rewrite -[RHS](AdjointFunctors.hom_invK Adj _ _ f a). Qed.
 
-Lemma univmap_FreeLModule_uniq (g : {hom[LModules R] {freemod R[A]} -> M}) :
+Lemma univmap_FreeLModule_uniq (g : {hom[LModules R] {freelmod R[A]} -> M}) :
   (forall a : A, g [fm / a |-> 1] = f a) -> g =m= univmap_FreeLModule.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
@@ -1614,12 +1808,12 @@ End UniversalProperty.
 
 Section FunctorialityInRing.
 (* shouldn't f be a {hom[Rings] R -> S} ??? *)
-Variable (A : Sets) (R S : Rings) (f : {rmorphism R -> S}).
+Variable (E : Sets) (R S : Rings) (f : {rmorphism R -> S}).
 
-Definition homRing_FreeLModule (m : {freemod R[A]}) : {freemod S[A]} :=
+Definition homRing_FreeLModule (m : {freelmod R[E]}) : {freelmod S[E]} :=
   \sum_(i <- finsupp m) [fm / i |-> f (m i)].
-Lemma homRing_FreeLModuleP (a : A) :
-  homRing_FreeLModule [fm / a |-> 1] = [fm / a |-> 1].
+Lemma homRing_FreeLModuleP (e : E) :
+  homRing_FreeLModule [fm / e |-> 1] = [fm / e |-> 1].
 Proof.
 by rewrite /homRing_FreeLModule finsupp_fm1 /= big_seq_fset1 fm1E eqxx rmorph1.
 Qed.
@@ -1640,7 +1834,7 @@ rewrite -!(finsupp_widen _ (S := finsupp x `|` finsupp y)%fset) /=.
   by rewrite subr0.
 Qed.
 HB.instance Definition _ :=
-  GRing.isZmodMorphism.Build {freemod R[A]} {freemod S[A]}
+  GRing.isZmodMorphism.Build {freelmod R[E]} {freelmod S[E]}
     homRing_FreeLModule homRing_FreeLModule_is_zmod_morphism.
 
 Fact homRing_FreeLModule_is_scalable :
@@ -1656,12 +1850,12 @@ apply/fsfunP => b; rewrite !scalefmE !fm1E.
 by case: eqP => _; rewrite ?mulr0 // rmorphM.
 Qed.
 HB.instance Definition _ :=
-  GRing.isScalable.Build R {freemod R[A]} {freemod S[A]}
+  GRing.isScalable.Build R {freelmod R[E]} {freelmod S[E]}
     (f \; *:%R) homRing_FreeLModule homRing_FreeLModule_is_scalable.
 
 Lemma homRing_FreeLModule_uniq
-  (g : {linear {freemod R[A]} -> {freemod S[A]} | f \; *:%R}) :
-  (forall a, g [fm / a |-> 1] = [fm / a |-> 1]) -> g =m= homRing_FreeLModule.
+  (g : {linear {freelmod R[E]} -> {freelmod S[E]} | f \; *:%R}) :
+  (forall e, g [fm / e |-> 1] = [fm / e |-> 1]) -> g =m= homRing_FreeLModule.
 Proof.
 move=> eq; apply: linear_fm_scaleE => //= x.
 by rewrite eq homRing_FreeLModuleP.
@@ -1670,17 +1864,17 @@ Qed.
 End FunctorialityInRing.
 
 Section HomRingFreeLModuleFunctor.
-Variables (A : Sets) (R S T : Rings).
+Variables (E : Sets) (R S T : Rings).
 
 Fact homRing_FreeLModule_ext (f g : {rmorphism R -> S}) :
-  f =m= g -> homRing_FreeLModule f (A := A) =m= homRing_FreeLModule g (A := A).
+  f =m= g -> homRing_FreeLModule f (E := E) =m= homRing_FreeLModule g (E := E).
 Proof.
 move=> eq; apply: linear_fm_scaleE => /= [r x /= |x].
   by rewrite [f r](eq r).
 by rewrite !homRing_FreeLModuleP.
 Qed.
 Fact homRing_FreeLModule_id :
-  homRing_FreeLModule (A := A) (R := R) idfun =m= idfun.
+  homRing_FreeLModule (E := E) (R := R) idfun =m= idfun.
 Proof.
 move=> eq; apply: linear_fm_scaleE => //= x.
 by rewrite !homRing_FreeLModuleP.
@@ -1689,22 +1883,22 @@ Qed.
 Variables (f : {rmorphism R -> S}) (g : {rmorphism S -> T}).
 
 #[local] Notation comp :=
-  (homRing_FreeLModule g (A := A) \@ homRing_FreeLModule f (A := A)).
+  (homRing_FreeLModule g (E := E) \@ homRing_FreeLModule f (E := E)).
 
-Let comp := homRing_FreeLModule g (A := A) \@ homRing_FreeLModule f (A := A).
+Let comp := homRing_FreeLModule g (E := E) \@ homRing_FreeLModule f (E := E).
 Let comp_is_scalable : scalable_for (g \o f \; *:%R) comp.
 Proof. by rewrite /comp => r x /=; rewrite !linearZ_LR /=. Qed.
 
 (** Avoid declaring as a a canonical instance => non forgetful inheritance *)
 (** See: https://rocq-prover.zulipchat.com/#narrow/channel/237664-math-comp-users/topic/Linearity.20w.2Er.2Et.20change.20of.20scalar.20and.20compose.20map/near/610998680 *)
 Let fmadd := GRing.Additive.on comp.
-Let fmscal := GRing.isScalable.Build R {freemod R[A]} {freemod T[A]}
+Let fmscal := GRing.isScalable.Build R {freemod R[E]} {freemod T[E]}
                  (g \o f \; *:%R) (Hom.sort comp) comp_is_scalable.
 Definition comp_homRing_FreeLModule :
-  {linear {freemod R[A]} -> {freemod T[A]} | g \o f \; *:%R} :=
+  {linear {freelmod R[E]} -> {freelmod T[E]} | g \o f \; *:%R} :=
       HB.pack (Hom.sort comp) fmadd fmscal.
 
-Fact homRing_FreeLModule_comp : comp =m= homRing_FreeLModule (g \o f) (A := A).
+Fact homRing_FreeLModule_comp : comp =m= homRing_FreeLModule (g \o f) (E := E).
 Proof.
 apply: (linear_fm_scaleE (f := comp_homRing_FreeLModule)) => //= x.
 by rewrite !homRing_FreeLModuleP.
@@ -1758,7 +1952,7 @@ Notation forget_SemiRings_to_Monoids := ForgetSemiRings_to_Monoids.functor.
 Lemma forget_SemiRings_to_MonoidsE a b (f : {hom[SemiRings] a -> b}) :
   forget_SemiRings_to_Monoids # f = multMon_mor f :> (_ -> _).
 Proof. by []. Qed.
-Definition forget_ComSemiRings_to_ComMonoids :=
+Notation forget_ComSemiRings_to_ComMonoids :=
   ForgetSemiRings_to_Monoids.functorCom.
 Lemma forget_ComSemiRings_to_ComMonoidsE a b (f : {hom[ComSemiRings] a -> b}) :
   forget_ComSemiRings_to_ComMonoids # f =
@@ -1816,19 +2010,19 @@ HB.instance Definition _ :=
 Local Open Scope monoid_scope.
 
 (* Adjunction Free L-modules -| forget Algebras -> Monoids *)
-Definition monalg (R : Rings) (A : Monoids) := {freemod R[A]}.
-Notation "{ 'monalg' R [ T ] }" := (monalg R T)
+Definition MonoidAlgebraT (R : Rings) (M : Monoids) := {freemod R[M]}.
+Notation "{ 'monalg' R [ T ] }" := (MonoidAlgebraT R T)
   (at level 0, format "{ 'monalg'  R [ T ] }").
 
 Module MonoidAlgebra.
 Section MonoidAlgebra.
 
-Variable (R : Rings) (A : Monoids).
-Implicit Types (r s : R) (a b c : A) (x y z : {monalg R[A]}).
+Variable (R : Rings) (M : Monoids).
+Implicit Types (r s : R) (a b c : M) (x y z : {monalg R[M]}).
 
-Definition one_ma : {monalg R[A]} := [fm / 1 |-> 1].
-Definition mul_mma a : {hom[LModules R] {monalg R[A]} -> {monalg R[A]}} :=
-  (@FreeLModule R) # [the {hom[Sets] A -> A} of *%M a].
+Definition one_ma : {monalg R[M]} := [fm / 1 |-> 1].
+Definition mul_mma a : {hom[LModules R] {monalg R[M]} -> {monalg R[M]}} :=
+  (@FreeLModule R) # [the {hom[Sets] M -> M} of *%M a].
 Lemma mul_mma_comp a b : mul_mma b \@ mul_mma a =m= mul_mma (b * a).
 Proof.
 rewrite /mul_mma -(functor_o (FreeLModule R)).
@@ -1839,7 +2033,7 @@ Lemma mul_mmacE a b r : mul_mma a [fm / b |-> r] = [fm / a * b |-> r].
 Proof. by rewrite /mul_mma /= hom_flmc. Qed.
 
 Let mul_mma_fun x a := mul_mma a x.
-Definition mul_mar x : {hom[LModules R] {monalg R[A]} -> {monalg R[A]}} :=
+Definition mul_mar x : {hom[LModules R] {monalg R[M]} -> {monalg R[M]}} :=
   univmap_FreeLModule (mul_mma_fun x).
 Lemma mul_mar1E x a : mul_mar x [fm / a |-> 1] = mul_mma a x.
 Proof. by rewrite /mul_mar univmap_FreeLModuleP /mul_mma_fun. Qed.
@@ -1880,8 +2074,8 @@ pose f := fun z => mul_mar x z + mul_mar y z; rewrite -[RHS]/(f z).
 have lin_f : linear f.
   move => c u v.
   by rewrite /f -!linear_of_LmodE !linearP scalerDr addrACA -!addrA.
-pose flM := @isHom.Build (LModules R) {monalg R[A]} {monalg R[A]} f lin_f.
-pose fL : {hom[LModules R] {monalg R[A]} -> {monalg R[A]}} := HB.pack f flM.
+pose flM := @isHom.Build (LModules R) {monalg R[M]} {monalg R[M]} f lin_f.
+pose fL : {hom[LModules R] {monalg R[M]} -> {monalg R[M]}} := HB.pack f flM.
 apply: (FreeLModuleE (g := fL)) => a.
 rewrite /fL /f.
 rewrite [RHS]/(mul_mar x [fm / a |-> 1] + mul_mar y [fm / a |-> 1]) !mul_mar1E.
@@ -1895,8 +2089,10 @@ have /[swap] -> := oner_eq0 R.
 by rewrite eqxx.
 Qed.
 #[export]
+HB.instance Definition _ := GRing.Lmodule.on {monalg R[M]}.
+#[export]
 HB.instance Definition _ :=
-  GRing.Zmodule_isNzRing.Build {freemod R[A]}
+  GRing.Zmodule_isNzRing.Build {monalg R[M]}
              mul_maA mul_1ma mul_ma1 mul_maDl mul_maDr one_ma_neq0.
 
 Fact scaler_maAl r x y : (r *: (x * y) = (r *: x) * y)%R.
@@ -1907,7 +2103,7 @@ by rewrite /GRing.mul /= fmcZE !mul_maccE [LHS]fmcZE mulrA.
 Qed.
 #[export]
 HB.instance Definition _ :=
-  GRing.Lmodule_isLalgebra.Build R {freemod R[A]} scaler_maAl.
+  GRing.Lmodule_isLalgebra.Build R {monalg R[M]} scaler_maAl.
 
 End MonoidAlgebra.
 
@@ -1916,47 +2112,57 @@ HB.reexport MonoidAlgebra.
 
 Section Theory.
 
-Variable (R : Rings) (A : Monoids).
-Implicit Types (r s : R) (a b c : A) (x y z : {monalg R[A]}).
+Variable (R : Rings) (M : Monoids).
+Implicit Types (r s : R) (a b c : M) (x y z : {monalg R[M]}).
 
-Lemma onemaE : [fm / 1 |-> 1%R] = 1%R :> {monalg R[A]}.
+#[local] Notation "[ 'ma' / d ]" := ([fm / d] : {monalg R[M]})
+  (at level 0, format "[ 'ma'  /  d ]") : ring_scope.
+
+Lemma onemaE : [ma / 1 |-> 1%R] = 1%R.
 Proof. by []. Qed.
 
 Lemma mulmacE a b r s :
-  ([fm / a |-> r] * [fm / b |-> s])%R = [fm / a * b |-> r * s].
+  ([ma / a |-> r] * [ma / b |-> s])%R = [ma / a * b |-> r * s].
 Proof. by rewrite [LHS]/GRing.mul /= !mul_maccE. Qed.
 Lemma mulmaE a b :
-  ([fm / a |-> 1] * [fm / b |-> 1])%R = [fm / a * b |-> 1] :> {monalg R[A]}.
+  ([ma / a |-> 1] * [ma / b |-> 1])%R = [ma / a * b |-> 1] :> {monalg R[M]}.
 Proof. by rewrite mulmacE mulr1. Qed.
-Lemma prodmacE (I : Type) (f : I -> A) (g : I -> R) (s : seq I) :
-  [fm / \prod_(i <- s) f i |-> (\prod_(i <- s) g i)%R] =
-    (\prod_(i <- s) [fm / f i |-> g i])%R :> {monalg R[A]}.
+Lemma prodmacE (I : Type) (f : I -> M) (g : I -> R) (s : seq I) :
+  [ma / \prod_(i <- s) f i |-> (\prod_(i <- s) g i)%R] =
+    (\prod_(i <- s) [ma / f i |-> g i])%R :> {monalg R[M]}.
 Proof.
 elim: s => [| s0 s IHs]; first by rewrite !big_nil -onemaE.
 by rewrite !big_cons -mulmacE IHs.
 Qed.
-Lemma prodmaE (I : Type) (f : I -> A) (s : seq I) :
-  [fm / \prod_(i <- s) f i |-> 1] =
-    (\prod_(i <- s) [fm / f i |-> 1])%R :> {monalg R[A]}.
+Lemma prodmaE (I : Type) (f : I -> M) (s : seq I) :
+  [ma / \prod_(i <- s) f i |-> 1] =
+    (\prod_(i <- s) [ma / f i |-> 1])%R :> {monalg R[M]}.
 Proof. by have := prodmacE f (fun _=> 1%R) s; rewrite big1_eq. Qed.
 Lemma mulmaccC a b :
-  a * b = b * a -> @GRing.comm {monalg R[A]} [fm / a |-> 1] [fm / b |-> 1].
+  a * b = b * a -> @GRing.comm {monalg R[M]} [ma / a |-> 1] [ma / b |-> 1].
 Proof. by rewrite /GRing.comm => comm; rewrite !mulmacE comm. Qed.
+
+Lemma linear_maE (N : lmodType R) (f g : {linear {monalg R[M]} -> N}) :
+  (forall x : M, f [ma / x |-> 1] = g [ma / x |-> 1]) -> f =1 g.
+Proof. exact: linear_fm_scaleE. Qed.
 
 End Theory.
 End Exports.
 End MonoidAlgebra.
 HB.export MonoidAlgebra.Exports.
 
+Notation "[ 'ma' / d ]" := ([fm / d] : {monalg _[_]})
+  (at level 0, format "[ 'ma'  /  d ]") : ring_scope.
+
 
 Section FunctorMonoidLAlgebra.
 Variable R : Rings.
 
 Section Morphisms.
-Variables (A B : Monoids) (f : {hom[Monoids] A -> B}).
+Variables (M N : Monoids) (f : {hom[Monoids] M -> N}).
 
-Definition hom_fun (a : A) : {monalg R[B]} := [fm / f a |-> 1].
-Definition hom_MonoidLAlgebra : {monalg R[A]} -> {monalg R[B]} :=
+Definition hom_fun (m : M) : {monalg R[N]} := [ma / f m |-> 1].
+Definition hom_MonoidLAlgebra : {monalg R[M]} -> {monalg R[N]} :=
   univmap_FreeLModule hom_fun.
 
 Fact hom_MonoidLAlgebra_is_lalg_morphism : lalg_morphism hom_MonoidLAlgebra.
@@ -1975,50 +2181,52 @@ rewrite /hom_fun !fm1ZE mulmacE.
 by have /= -> := mmorphM f a b.
 Qed.
 HB.instance Definition _ :=
-  @isHom.Build (LAlgebras R) {monalg R[A]} {monalg R[B]}
-    (hom_MonoidLAlgebra : [the LAlgebras R of {monalg R[A]}] -> _)
+  @isHom.Build (LAlgebras R) {monalg R[M]} {monalg R[N]}
+    (hom_MonoidLAlgebra : [the LAlgebras R of {monalg R[M]}] -> _)
     hom_MonoidLAlgebra_is_lalg_morphism.
 Definition MonoidLAlgebra_mor
-  : {hom[LAlgebras R] {monalg R[A]} -> {monalg R[B]}} := hom_MonoidLAlgebra.
+  : {hom[LAlgebras R] {monalg R[M]} -> {monalg R[N]}} := hom_MonoidLAlgebra.
 
 End Morphisms.
 
 
 Fact MonoidLAlgebra_ext : FunctorLaws.ext MonoidLAlgebra_mor.
 Proof.
-rewrite /MonoidLAlgebra_mor => A B f g eq.
-apply univmap_FreeLModule_uniq => a.
+rewrite /MonoidLAlgebra_mor => M N f g eq.
+apply univmap_FreeLModule_uniq => m.
 by rewrite univmap_FreeLModuleP /hom_fun /= eq.
 Qed.
 Fact MonoidLAlgebra_id : FunctorLaws.id MonoidLAlgebra_mor.
 Proof.
-rewrite /MonoidLAlgebra_mor /= => A; apply fsym => x /=.
+rewrite /MonoidLAlgebra_mor /= => M; apply fsym => x /=.
 by have <- := univmap_FreeLModule_uniq (f := hom_fun idfun) (g := idfun) _ x.
 Qed.
 Fact MonoidLAlgebra_comp  : FunctorLaws.comp MonoidLAlgebra_mor.
 Proof.
-rewrite /MonoidLAlgebra_mor => A B C f g; apply fsym => x.
+rewrite /MonoidLAlgebra_mor => M N P f g; apply fsym => x.
 set gf := (X in X x = _).
 have <- // := univmap_FreeLModule_uniq (f := hom_fun (f \o g)) (g := gf) _ x.
 by move=> {x} a; rewrite [LHS]compapp !univmap_FreeLModuleP.
 Qed.
-Definition MonoidLAlgebra (T : Monoids) : LAlgebras R := {monalg R[T]}.
+Definition MonoidLAlgebra_functor (T : Monoids) : LAlgebras R := {monalg R[T]}.
 HB.instance Definition _ :=
   @isFunctor.Build Monoids (LAlgebras R)
-    MonoidLAlgebra MonoidLAlgebra_mor
+    MonoidLAlgebra_functor MonoidLAlgebra_mor
     MonoidLAlgebra_ext MonoidLAlgebra_id MonoidLAlgebra_comp.
 
 End FunctorMonoidLAlgebra.
+Definition MonoidLAlgebra (R : Rings) :
+  {functor Monoids -> LAlgebras R} := MonoidLAlgebra_functor R.
 
 
 Section FunctorialityInRing.
-Variable (R S : Rings) (f : {rmorphism R -> S}) (A : Monoids).
+Variable (R S : Rings) (f : {rmorphism R -> S}) (M : Monoids).
 
-Definition homRing_MonoidLAlgebra : {monalg R[A]} -> {monalg S[A]} :=
-  @homRing_FreeLModule A R S f.
+Definition homRing_MonoidLAlgebra : {monalg R[M]} -> {monalg S[M]} :=
+  @homRing_FreeLModule M R S f.
 HB.instance Definition _ := GRing.Linear.on homRing_MonoidLAlgebra.
-Lemma homRing_MonoidLAlgebraP (a : A) :
-  homRing_MonoidLAlgebra [fm / a |-> 1] = [fm / a |-> 1].
+Lemma homRing_MonoidLAlgebraP (m : M) :
+  homRing_MonoidLAlgebra [ma / m |-> 1] = [ma / m |-> 1].
 Proof. by rewrite /homRing_MonoidLAlgebra homRing_FreeLModuleP. Qed.
 
 Fact homRing_MonoidLAlgebra_is_monoid_morphism :
@@ -2036,30 +2244,30 @@ rewrite !linearZ /= !homRing_FreeLModuleP.
 by rewrite !fm1ZE mulmacE rmorphM.
 Qed.
 HB.instance Definition _ :=
-  GRing.isMonoidMorphism.Build {monalg R[A]} {monalg S[A]}
+  GRing.isMonoidMorphism.Build {monalg R[M]} {monalg S[M]}
     homRing_MonoidLAlgebra homRing_MonoidLAlgebra_is_monoid_morphism.
 
 Lemma homRing_MonoidLAlgebra_uniq
-  (g : {lrmorphism {monalg R[A]} -> {monalg S[A]} | f \; *:%R }) :
-  (forall a, g [fm / a |-> 1] = [fm / a |-> 1]) -> g =1 homRing_MonoidLAlgebra.
-Proof. exact: homRing_FreeLModule_uniq. Qed.
+  (g : {lrmorphism {monalg R[M]} -> {monalg S[M]} | f \; *:%R }) :
+  (forall m, g [ma / m |-> 1] = [ma / m |-> 1]) -> g =m= homRing_MonoidLAlgebra.
+Proof. exact: (homRing_FreeLModule_uniq (g := g)). Qed.
 
 End FunctorialityInRing.
 
 Section HomRingMonoidLAlgebraFunctor.
-Variables (A : Monoids) (R S T : Rings).
+Variables (M : Monoids) (R S T : Rings).
 
 Fact homRing_MonoidLAlgebra_ext (f g : {rmorphism R -> S}) :
   f =m= g
-  -> homRing_MonoidLAlgebra f (A := A) =m= homRing_MonoidLAlgebra g (A := A).
+  -> homRing_MonoidLAlgebra f (M := M) =m= homRing_MonoidLAlgebra g (M := M).
 Proof. exact: homRing_FreeLModule_ext. Qed.
 Fact homRing_MonoidLAlgebra_id :
-  homRing_MonoidLAlgebra (A := A) (R := R) idfun =m= idfun.
+  homRing_MonoidLAlgebra (M := M) (R := R) idfun =m= idfun.
 Proof. exact: homRing_FreeLModule_id. Qed.
 Fact homRing_MonoidLAlgebra_comp
   (f : {rmorphism R -> S}) (g : {rmorphism S -> T}) :
-  homRing_MonoidLAlgebra g (A := A) \@ homRing_MonoidLAlgebra f (A := A)
-  =m= homRing_MonoidLAlgebra (g \o f) (A := A).
+  homRing_MonoidLAlgebra g (M := M) \@ homRing_MonoidLAlgebra f (M := M)
+  =m= homRing_MonoidLAlgebra (g \o f) (M := M).
 Proof. exact: homRing_FreeLModule_comp. Qed.
 
 End HomRingMonoidLAlgebraFunctor.
@@ -2069,36 +2277,36 @@ Section FunctorMonoidAlgebra.
 
 Variable (R : ComRings).
 
-Fact scaler_maAr (A : Monoids) r (x y : {freemod R[A]}) :
+Fact scaler_maAr (M : Monoids) r (x y : {monalg R[M]}) :
   (r *: (x * y) = x * (r *: y))%R.
 Proof.
 rewrite -(fmE y) [in RHS]scaler_sumr !mulr_sumr scaler_sumr; apply eq_bigr => a _.
 rewrite -(fmE x) !mulr_suml !scaler_sumr; apply eq_bigr => b _.
 by rewrite !(mulmacE, fmcZE) mulrCA.
 Qed.
-HB.instance Definition _ (A : Monoids) :=
-  GRing.Lalgebra_isAlgebra.Build R {freemod R[A]} (@scaler_maAr A).
+HB.instance Definition _ (M : Monoids) :=
+  GRing.Lalgebra_isAlgebra.Build R {monalg R[M]} (@scaler_maAr M).
 
-Lemma monalgE (A : Monoids) (T : Algebras R)
-  (f g : {hom[Algebras R] {monalg R[A]} -> T}) :
-  (forall a : A, f [fm / a |-> 1] = g [fm / a |-> 1]) -> f =m= g.
+Lemma monalgE (M : Monoids) (A : Algebras R)
+  (f g : {hom[Algebras R] {monalg R[M]} -> A}) :
+  (forall m : M, f [ma / m |-> 1] = g [ma / m |-> 1]) -> f =m= g.
 Proof.
 move=> eq x; rewrite -(lrmorphism_of_AlgebrasE f) -(lrmorphism_of_AlgebrasE g).
-exact: linear_fmE.
+exact: linear_maE.
 Qed.
 
 
 Section MonoidAlgebraHoms.
-Variables (A B : Monoids) (f : {hom[Monoids] A -> B}).
+Variables (M N : Monoids) (f : {hom[Monoids] M -> N}).
 
 Definition hom_MonoidAlgebra :=
-  (@hom_MonoidLAlgebra R A B f: [the Algebras R of {monalg R[A]}] -> _).
+  (@hom_MonoidLAlgebra R M N f: [the Algebras R of {monalg R[M]}] -> _).
 
 HB.instance Definition _  :=
-  @isHom.Build (Algebras R) {monalg R[A]} {monalg R[B]}
-    hom_MonoidAlgebra (@hom_MonoidLAlgebra_is_lalg_morphism R A B f).
+  @isHom.Build (Algebras R) {monalg R[M]} {monalg R[N]}
+    hom_MonoidAlgebra (@hom_MonoidLAlgebra_is_lalg_morphism R M N f).
 Definition MonoidAlgebra_mor
-  : {hom[Algebras R] {monalg R[A]} -> {monalg R[B]}} := hom_MonoidAlgebra.
+  : {hom[Algebras R] {monalg R[M]} -> {monalg R[N]}} := hom_MonoidAlgebra.
 
 End MonoidAlgebraHoms.
 
@@ -2108,60 +2316,61 @@ Fact MonoidAlgebra_id : FunctorLaws.id MonoidAlgebra_mor.
 Proof. exact: MonoidLAlgebra_id. Qed.
 Fact MonoidAlgebra_comp  : FunctorLaws.comp MonoidAlgebra_mor.
 Proof. exact: MonoidLAlgebra_comp. Qed.
-Definition MonoidAlgebra (T : Monoids) : Algebras R := {monalg R[T]}.
+Definition MonoidAlgebra_functor (M : Monoids) : Algebras R := {monalg R[M]}.
 HB.instance Definition _ :=
   @isFunctor.Build Monoids (Algebras R)
-    MonoidAlgebra MonoidAlgebra_mor
+    MonoidAlgebra_functor MonoidAlgebra_mor
     MonoidAlgebra_ext MonoidAlgebra_id MonoidAlgebra_comp.
 
 End FunctorMonoidAlgebra.
+Definition MonoidAlgebra (R : ComRings) : {functor Monoids -> Algebras R}
+  := MonoidAlgebra_functor R.
 
 
 (** Adjunction Monoid Algebras |- forget Algebras to Monoids *)
-Definition forget_Algebras_to_Monoids R : {functor Algebras R -> Monoids} :=
-  forget_SemiRings_to_Monoids
-    \O forget_Rings_to_SemiRings
-    \O (@forget_LAlgebras_to_Rings R) \O (@forget_Algebras_to_LAlgebras R).
+Definition forget_Algebras_to_Monoids R :=
+  forget_SemiRings_to_Monoids \O forget_Rings_to_SemiRings
+    \O @forget_LAlgebras_to_Rings R \O @forget_Algebras_to_LAlgebras R.
 
 
 Module MonoidAlgebraAdjoint.
 Section Adjoint.
 Variable R : ComRings.
-Implicit Types (A : Monoids) (T : Algebras R).
+Implicit Types (M : Monoids) (A : Algebras R).
 
 Local Notation forgetf := (forget_Algebras_to_Monoids R).
 Local Notation fMA := (MonoidAlgebra R).
 
 Section def_ETA.
-Variable A : Monoids.
+Variable M : Monoids.
 
-Definition eta_fun (a : A) : (forgetf \O fMA) A := @to_multMon _ [fm / a |-> 1].
+Definition eta_fun (m : M) : (forgetf \O fMA) M := @to_multMon _ [ma / m |-> 1].
 Fact eta_fun_monmorphism : monmorphism eta_fun.
 Proof.
-split => //; rewrite /eta_fun => a b.
+split => //; rewrite /eta_fun => x y.
 by rewrite monME mulmacE mulr1.
 Qed.
 HB.instance Definition _ :=
-  isHom.Build Monoids A ((forgetf \O fMA) A) eta_fun eta_fun_monmorphism.
+  isHom.Build Monoids M ((forgetf \O fMA) M) eta_fun eta_fun_monmorphism.
 
 End def_ETA.
 
 Definition eta : FId ~~> forgetf \O fMA := eta_fun.
 Fact eta_natural : naturality FId (forgetf \O fMA) eta.
 Proof.
-move=> /= A B h x /=; rewrite FIdf /eta_fun /=.
+move=> /= M N h x /=; rewrite FIdf /eta_fun /=.
 by rewrite /multMon_mor /= /hom_MonoidAlgebra univmap_FreeLModuleP.
 Qed.
 HB.instance Definition _ :=
   @isNatural.Build Monoids Monoids FId (forgetf \O fMA) eta eta_natural.
 
 Section def_EPS.
-Variable T : Algebras R.
+Variable A : Algebras R.
 
-Definition eps_fun (m : (fMA \O forgetf) T) : T :=
-  (\sum_(i <- finsupp (m : {freemod R[_]})) (m i *: \val i)).
+Definition eps_fun (m : (fMA \O forgetf) A) : A :=
+  (\sum_(i <- finsupp (m : {monalg R[_]})) (m i *: \val i)).
 
-Lemma eps_fun1E t r : eps_fun [fm / t |-> r] = r *: \val t.
+Lemma eps_fun1E t r : eps_fun [ma / t |-> r] = r *: \val t.
 Proof.
 rewrite /eps_fun.
 case : (altP (r =P 0)) => [-> | /finsupp_fmZ ->].
@@ -2186,7 +2395,7 @@ rewrite -big_split /=; apply: eq_bigr => a _.
   by rewrite mulr0 addr0.
 Qed.
 HB.instance Definition _ :=
-  GRing.isLinear.Build R ((fMA \O forgetf) T) T _ eps_fun eps_fun_linear.
+  GRing.isLinear.Build R ((fMA \O forgetf) A) A _ eps_fun eps_fun_linear.
 
 Fact eps_fun_is_lalg_morphism : lalg_morphism eps_fun.
 Proof.
@@ -2200,7 +2409,7 @@ rewrite mulmacE !eps_fun1E /=.
 by rewrite -!scalerAr -!scalerAl scalerA mulrC.
 Qed.
 HB.instance Definition _ :=
-  isHom.Build (Algebras R) ((fMA \O forgetf) T) T
+  isHom.Build (Algebras R) ((fMA \O forgetf) A) A
     eps_fun eps_fun_is_lalg_morphism.
 
 End def_EPS.
@@ -2247,18 +2456,20 @@ Section UniversalProperty.
 
 Variable (R : ComRings).
 
-Variables (A : Monoids) (M : Algebras R)
-  (f : {hom[Monoids] A -> forget_Algebras_to_Monoids R M}).
+Variables (M : Monoids) (A : Algebras R)
+  (f : {hom[Monoids] M -> forget_Algebras_to_Monoids R A}).
 
 Let Adj := adjoint_MonoidAlgebra_forget_to_Monoids R.
 
-Definition univmap_MonoidAlgebra := AdjointFunctors.hom_inv Adj f.
+Definition univmap_MonoidAlgebra : {hom[Algebras R] {monalg R[M]} -> A}
+  := AdjointFunctors.hom_inv Adj f.
 
-Lemma univmap_MonoidAlgebraP a : univmap_MonoidAlgebra [fm / a |-> 1] = \val (f a).
-Proof. by rewrite -[in RHS](AdjointFunctors.hom_invK Adj _ _ f a). Qed.
+Lemma univmap_MonoidAlgebraP m :
+  univmap_MonoidAlgebra [fm / m |-> 1] = \val (f m).
+Proof. by rewrite -[in RHS](AdjointFunctors.hom_invK Adj _ _ f m). Qed.
 
-Lemma univmap_MonoidAlgebra_uniq (g : {hom[Algebras R] {monalg R[A]} -> M}) :
-  (forall a : A, g [fm / a |-> 1] = \val (f a)) -> g =m= univmap_MonoidAlgebra.
+Lemma univmap_MonoidAlgebra_uniq (g : {hom[Algebras R] {monalg R[M]} -> A}) :
+  (forall m : M, g [ma / m |-> 1] = \val (f m)) -> g =m= univmap_MonoidAlgebra.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
 move=> a; rewrite AdjointFunctors.hom_invK.
@@ -2267,25 +2478,28 @@ Qed.
 
 End UniversalProperty.
 
+Definition homRing_MonoidAlgebra (R S : ComRings) (f : {rmorphism R -> S})
+           (M : Monoids) := homRing_MonoidLAlgebra f (M := M).
+
 
 Definition FreeAlgebra R := MonoidAlgebra R \O FreeMonoid.
 Notation "{ 'freealg' R [ T ] }" := (FreeAlgebra R T)
   (at level 0, format "{ 'freealg'  R [ T ] }").
 
-Definition falg_gen {R} S i : {freealg R[S]} := [fm / [fmon i] |-> 1].
+Definition falg_gen {R} S i : {freealg R[S]} := [ma / [fmon i] |-> 1].
 
 Section FreeAlgebraTheory.
-Variable (R : ComRings) (A : Sets).
-Implicit Types (x y : {freealg R[A]}).
+Variable (R : ComRings) (E : Sets).
+Implicit Types (x y : {freealg R[E]}).
 
-Lemma freealg1E : 1%R = [fm / 1%M |-> 1] :> {freealg R[A]}.
+Lemma freealg1E : 1%R = [ma / 1%M |-> 1] :> {freealg R[E]}.
 Proof. by []. Qed.
 Lemma freealgE x :
   \sum_(m <- finsupp x) x m *: \prod_(i <- m) falg_gen i = x.
 Proof.
 rewrite -[RHS](fmE x); apply: eq_bigr => m _.
 rewrite -fm1ZE; congr (_ *: _).
-rewrite /falg_gen -prodmaE; congr [fm / _ |-> 1].
+rewrite /falg_gen -prodmaE; congr [ma / _ |-> 1].
 by rewrite freemonE.
 Qed.
 
@@ -2348,8 +2562,7 @@ Section UniversalProperty.
 
 Variable (R : ComRings).
 
-Variables (S : Sets) (A : Algebras R)
-  (f : {hom[Sets] S -> forget_Algebras_to_Sets R A}).
+Variables (E : Sets) (A : Algebras R) (f : {hom[Sets] E -> A}).
 
 Let Adj := adjoint_FreeAlgebra_forget_to_Sets R.
 
@@ -2361,58 +2574,58 @@ rewrite -[RHS](AdjointFunctors.hom_invK Adj _ _ f i) /=; repeat congr (_ _).
 by rewrite !HCompId /= !HIdComp /= HCompId.
 Qed.
 
-Lemma eta_FreeAlgebraE i : AdjointFunctors.eta Adj S i = falg_gen i.
+Lemma eta_FreeAlgebraE i : AdjointFunctors.eta Adj E i = falg_gen i.
 Proof.
 rewrite /= !HCompId /transf_from_multmon /transf_from_multmon_fun /=.
 by rewrite HIdComp /= HCompId.
 Qed.
 
-Lemma univmap_FreeAlgebra_uniq (g : {hom[Algebras R] {freealg R[S]} -> A}) :
-  (forall i : S, g (falg_gen i) = f i) -> g =m= univmap_FreeAlgebra.
+Lemma univmap_FreeAlgebra_uniq (g : {hom[Algebras R] {freealg R[E]} -> A}) :
+  (forall e : E, g (falg_gen e) = f e) -> g =m= univmap_FreeAlgebra.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
-move=> i; rewrite AdjointFunctors.hom_invK -{}eq.
-by have /= -> := eta_FreeAlgebraE i.
+move=> e; rewrite AdjointFunctors.hom_invK -{}eq.
+by have /= -> := eta_FreeAlgebraE e.
 Qed.
 
 End UniversalProperty.
 
 
 Section FunctorialityInRing.
-Variable (R S : ComRings) (f : {rmorphism R -> S}) (A : Sets).
+Variable (R S : ComRings) (f : {rmorphism R -> S}) (E : Sets).
 
-Definition homRing_FreeAlgebra : {freealg R[A]} -> {freealg S[A]} :=
-  @homRing_MonoidLAlgebra R S f (FreeMonoid A).
+Definition homRing_FreeAlgebra : {freealg R[E]} -> {freealg S[E]} :=
+  @homRing_MonoidLAlgebra R S f (FreeMonoid E).
 HB.instance Definition _ := GRing.LRMorphism.on homRing_FreeAlgebra.
 
 Lemma homRing_FreeAlgebraP i :
   homRing_FreeAlgebra (falg_gen i) = falg_gen i.
 Proof. by rewrite /homRing_FreeAlgebra homRing_MonoidLAlgebraP. Qed.
 Lemma homRing_FreeAlgebra_uniq
-  (g : {lrmorphism {freealg R[A]} -> {freealg S[A]} | f \; *:%R }) :
-  (forall i, g (falg_gen i) = falg_gen i) ->
+  (g : {lrmorphism {freealg R[E]} -> {freealg S[E]} | f \; *:%R }) :
+  (forall e : E, g (falg_gen e) = falg_gen e) ->
   g =m= homRing_FreeAlgebra.
 Proof.
-move=> eq; apply: homRing_MonoidLAlgebra_uniq => /= a.
-rewrite -!/[fm / _ |-> _] -(freemonE a) !prodmaE rmorph_prod.
-by apply: eq_bigr => i _; exact: eq.
+move=> eq; apply: homRing_MonoidLAlgebra_uniq => /= x.
+rewrite -!/[fm / _ |-> _] -(freemonE x) !prodmaE rmorph_prod.
+by apply: eq_bigr => e _; exact: eq.
 Qed.
 
 End FunctorialityInRing.
 
 Section HomRingFreeAlgebraFunctor.
-Variables (A : Monoids) (R S T : ComRings).
+Variables (M : Monoids) (R S T : ComRings).
 
 Fact homRing_FreeAlgebra_ext (f g : {rmorphism R -> S}) :
-  f =m= g -> homRing_FreeAlgebra f (A := A) =m= homRing_FreeAlgebra g (A := A).
+  f =m= g -> homRing_FreeAlgebra f (E := M) =m= homRing_FreeAlgebra g (E := M).
 Proof. exact: homRing_FreeLModule_ext. Qed.
 Fact homRing_FreeAlgebra_id :
-  homRing_FreeAlgebra (A := A) (R := R) idfun =m= idfun.
+  homRing_FreeAlgebra (E := M) (R := R) idfun =m= idfun.
 Proof. exact: homRing_FreeLModule_id. Qed.
 Fact homRing_FreeAlgebra_comp
   (f : {rmorphism R -> S}) (g : {rmorphism S -> T}):
-  homRing_FreeAlgebra g (A := A) \@ homRing_FreeAlgebra f (A := A)
-  =m= homRing_FreeAlgebra (g \o f) (A := A).
+  homRing_FreeAlgebra g (E := M) \@ homRing_FreeAlgebra f (E := M)
+  =m= homRing_FreeAlgebra (g \o f) (E := M).
 Proof. exact: homRing_FreeLModule_comp. Qed.
 
 End HomRingFreeAlgebraFunctor.
@@ -2420,42 +2633,39 @@ End HomRingFreeAlgebraFunctor.
 
 Section ComMonoidAlgebra.
 
-Variable (R : ComRings) (A : ComMonoids).
-Implicit Types (r s : R) (a b c : A) (x y z : {monalg R[A]}).
+Variable (R : ComRings) (M : ComMonoids).
+Implicit Types (r s : R) (a b c : M) (x y z : {monalg R[M]}).
 
-Fact mulma_comm : commutative (@GRing.mul {monalg R[A]}).
+Fact mulma_comm : commutative (@GRing.mul {monalg R[M]}).
 Proof.
 move=> x y; rewrite -(fmE y) mulr_suml mulr_sumr; apply eq_bigr => b _.
 rewrite -(fmE x) mulr_suml mulr_sumr; apply eq_bigr => a _.
 by rewrite !mulmacE mulrC mulmC.
 Qed.
-HB.instance Definition _ := GRing.Lalgebra.on {monalg R[A]}.
 HB.instance Definition _ :=
-  GRing.PzSemiRing_hasCommutativeMul.Build {monalg R[A]} mulma_comm.
-HB.instance Definition _ :=
-  GRing.Lalgebra_isComAlgebra.Build R {monalg R[A]}.
+  GRing.PzSemiRing_hasCommutativeMul.Build {monalg R[M]} mulma_comm.
 
 End ComMonoidAlgebra.
 
 
 Section ComMonoidAlgebraHoms.
 
-Variables (R : ComRings) (A B : ComMonoids) (f : A -> B).
-Hypothesis f_homcm : @inhom ComMonoids A B f.
+Variables (R : ComRings) (M N : ComMonoids) (f : M -> N).
+Hypothesis f_homcm : @inhom ComMonoids M N f.
 
-Let fm : (A : Monoids) -> (B : Monoids) := f.
-Lemma fm_homm : @inhom Monoids A B fm.
+Let fm : (M : Monoids) -> (N : Monoids) := f.
+Lemma fm_homm : @inhom Monoids M N fm.
 Proof. exact: f_homcm. Qed.
 HB.instance Definition _  :=
-  isHom.Build Monoids (A : Monoids) (B : Monoids) fm fm_homm.
-Definition fm_tmp : {hom[Monoids] A -> B} := fm.
-Definition ComMonoidAlgebra_fun : ({monalg R[A]} : ComAlgebras R)
-             -> ({monalg R[B]} : ComAlgebras R) := MonoidAlgebra R # fm_tmp.
+  isHom.Build Monoids (M : Monoids) (N : Monoids) fm fm_homm.
+Definition fm_tmp : {hom[Monoids] M -> N} := fm.
+Definition ComMonoidAlgebra_fun : ({monalg R[M]} : ComAlgebras R)
+             -> ({monalg R[N]} : ComAlgebras R) := MonoidAlgebra R # fm_tmp.
 HB.instance Definition _  :=
-  @isHom.Build (ComAlgebras R) {monalg R[A]} {monalg R[B]}
-    ComMonoidAlgebra_fun (@hom_MonoidLAlgebra_is_lalg_morphism R A B fm).
+  @isHom.Build (ComAlgebras R) {monalg R[M]} {monalg R[N]}
+    ComMonoidAlgebra_fun (@hom_MonoidLAlgebra_is_lalg_morphism R M N fm).
 Definition ComMonoidAlgebra_mor_tmp :
-  {hom[ComAlgebras R] {monalg R[A]} -> {monalg R[B]}} := ComMonoidAlgebra_fun.
+  {hom[ComAlgebras R] {monalg R[M]} -> {monalg R[N]}} := ComMonoidAlgebra_fun.
 
 End ComMonoidAlgebraHoms.
 
@@ -2464,9 +2674,9 @@ Section FunctorComMonoidAlgebra.
 
 Variable R : ComRings.
 
-Definition forget_Hom_ComMonoid_to_Monoid A B (f : {hom[ComMonoids] A -> B}) :=
+Definition forget_Hom_ComMonoid_to_Monoid M N (f : {hom[ComMonoids] M -> N}) :=
   fm_tmp (isHom_inhom f).
-Definition ComMonoidAlgebra_mor A B (f : {hom[ComMonoids] A -> B}) :=
+Definition ComMonoidAlgebra_mor M N (f : {hom[ComMonoids] M -> N}) :=
   ComMonoidAlgebra_mor_tmp R (isHom_inhom f).
 
 Fact ComMonoidAlgebra_ext : FunctorLaws.ext ComMonoidAlgebra_mor.
@@ -2480,47 +2690,50 @@ exact: (MonoidLAlgebra_comp
     (forget_Hom_ComMonoid_to_Monoid f) (forget_Hom_ComMonoid_to_Monoid g)).
 Qed.
 
-Definition ComMonoidAlgebra (T : ComMonoids) : ComAlgebras R := {monalg R[T]}.
+Definition ComMonoidAlgebra_functor (M : ComMonoids) : ComAlgebras R
+  := {monalg R[M]}.
 HB.instance Definition _ :=
   @isFunctor.Build ComMonoids (ComAlgebras R)
-    ComMonoidAlgebra ComMonoidAlgebra_mor
+    ComMonoidAlgebra_functor ComMonoidAlgebra_mor
     ComMonoidAlgebra_ext ComMonoidAlgebra_id ComMonoidAlgebra_comp.
 
 End FunctorComMonoidAlgebra.
+Definition ComMonoidAlgebra (R : ComRings)
+  : {functor ComMonoids -> ComAlgebras R} := ComMonoidAlgebra_functor R.
+
 
 
 (** Adjunction ComMonoid Algebras |- forget ComAlgebras to ComMonoids *)
 Definition forget_ComAlgebras_to_ComMonoids R
-  : {functor ComAlgebras R -> ComMonoids}
   := forget_ComSemiRings_to_ComMonoids
     \O forget_ComRings_to_ComSemiRings \O forget_ComAlgebras_to_ComRings R.
 
 Module ComMonoidAlgebraAdjoint.
 Section Adjoint.
 Variable R : ComRings.
-Implicit Types (A : ComMonoids) (T : ComAlgebras R).
+Implicit Types (M : ComMonoids) (A : ComAlgebras R).
 
 Local Notation forgetf := (forget_ComAlgebras_to_ComMonoids R).
 Local Notation fMA := (ComMonoidAlgebra R).
 
 Section def_ETA.
-Variable A : ComMonoids.
+Variable M : ComMonoids.
 
-Definition eta_fun (a : A) : (forgetf \O fMA) A := @to_multMon _ [fm / a |-> 1].
+Definition eta_fun (m : M) : (forgetf \O fMA) M := @to_multMon _ [ma / m |-> 1].
 Fact eta_fun_monmorphism : monmorphism eta_fun.
 Proof.
 split => //; rewrite /eta_fun => a b.
 by rewrite monME mulmacE mulr1.
 Qed.
 HB.instance Definition _ :=
-  isHom.Build ComMonoids A ((forgetf \O fMA) A) eta_fun eta_fun_monmorphism.
+  isHom.Build ComMonoids M ((forgetf \O fMA) M) eta_fun eta_fun_monmorphism.
 
 End def_ETA.
 
 Definition eta : FId ~~> forgetf \O fMA := eta_fun.
 Fact eta_natural : naturality FId (forgetf \O fMA) eta.
 Proof.
-move=> /= A B h x /=; rewrite FIdf /eta_fun /=.
+move=> /= M N h x /=; rewrite FIdf /eta_fun /=.
 rewrite /ForgetSemiRings_to_Monoids.multComMon_mor /multMon_mor.
 by rewrite /= /hom_MonoidAlgebra univmap_FreeLModuleP.
 Qed.
@@ -2528,12 +2741,12 @@ HB.instance Definition _ :=
   @isNatural.Build ComMonoids ComMonoids FId (forgetf \O fMA) eta eta_natural.
 
 Section def_EPS.
-Variable T : ComAlgebras R.
+Variable A : ComAlgebras R.
 
-Definition eps_fun (m : (fMA \o forgetf) T) : T :=
-  (\sum_(i <- finsupp (m : {freemod R[_]})) (m i *: \val i)).
+Definition eps_fun (m : (fMA \o forgetf) A) : A :=
+  (\sum_(i <- finsupp (m : {monalg R[_]})) (m i *: \val i)).
 
-Lemma eps_fun1E t r : eps_fun [fm / t |-> r] = r *: \val t.
+Lemma eps_fun1E t r : eps_fun [ma / t |-> r] = r *: \val t.
 Proof.
 rewrite /eps_fun.
 case : (altP (r =P 0)) => [-> | /finsupp_fmZ ->].
@@ -2558,7 +2771,7 @@ rewrite -big_split /=; apply: eq_bigr => a _.
   by rewrite mulr0 addr0.
 Qed.
 HB.instance Definition _ :=
-  GRing.isLinear.Build R ((fMA \o forgetf) T) T _ eps_fun eps_fun_linear.
+  GRing.isLinear.Build R ((fMA \o forgetf) A) A _ eps_fun eps_fun_linear.
 
 Fact eps_fun_is_lalg_morphism : lalg_morphism eps_fun.
 Proof.
@@ -2572,7 +2785,7 @@ rewrite mulmacE !eps_fun1E /=.
 by rewrite -!scalerAr -!scalerAl scalerA mulrC.
 Qed.
 HB.instance Definition _ :=
-  isHom.Build (ComAlgebras R) ((fMA \o forgetf) T) T
+  isHom.Build (ComAlgebras R) ((fMA \o forgetf) A) A
     eps_fun eps_fun_is_lalg_morphism.
 
 End def_EPS.
@@ -2622,19 +2835,22 @@ Section UniversalProperty.
 
 Variable (R : ComRings).
 
-Variables (A : ComMonoids) (M : ComAlgebras R)
-  (f : {hom[ComMonoids] A -> forget_ComAlgebras_to_ComMonoids R M}).
+Variables (M : ComMonoids) (A : ComAlgebras R)
+  (f : {hom[ComMonoids] M -> forget_ComAlgebras_to_ComMonoids R A}).
 
 Let Adj := adjoint_ComMonoidAlgebra_forget_to_ComMonoids R.
 
-Definition univmap_ComMonoidAlgebra := AdjointFunctors.hom_inv Adj f.
+Definition univmap_ComMonoidAlgebra : {hom[ComAlgebras R] {monalg R[M]} -> A}
+  := AdjointFunctors.hom_inv Adj f.
 
 Lemma univmap_ComMonoidAlgebraP a :
-  univmap_ComMonoidAlgebra [fm / a |-> 1] = \val (f a).
+  univmap_ComMonoidAlgebra [ma / a |-> 1] = \val (f a).
 Proof. by rewrite -[in RHS](AdjointFunctors.hom_invK Adj _ _ f a). Qed.
 
-Lemma univmap_ComMonoidAlgebra_uniq (g : {hom[ComAlgebras R] {monalg R[A]} -> M}) :
-  (forall a : A, g [fm / a |-> 1] = \val (f a)) -> g =m= univmap_ComMonoidAlgebra.
+Lemma univmap_ComMonoidAlgebra_uniq
+  (g : {hom[ComAlgebras R] {monalg R[M]} -> A}) :
+  (forall a : M, g [ma / a |-> 1] = \val (f a))
+  -> g =m= univmap_ComMonoidAlgebra.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
 move=> a; rewrite AdjointFunctors.hom_invK.
@@ -2642,6 +2858,9 @@ by apply val_inj; rewrite -eq.
 Qed.
 
 End UniversalProperty.
+Definition homRing_ComMonoidAlgebra (R S : ComRings) (f : {rmorphism R -> S})
+           (M : ComMonoids) := homRing_MonoidAlgebra f (M := M).
+
 
 
 (** Fix the non HB forgetful inheritance ComSemiRings -> ComMonoids *)
@@ -2695,13 +2914,13 @@ Definition FreeComAlgebra R := ComMonoidAlgebra R \O FreeComMonoid.
 Notation "{ 'freecalg' R [ T ] }" := (FreeComAlgebra R T)
   (at level 0, format "{ 'freecalg'  R [ T ] }").
 
-Definition fcalg_gen R S i : {freecalg R[S]} := [fm / cmon_gen i |-> 1].
+Definition fcalg_gen R S i : {freecalg R[S]} := [ma / cmon_gen i |-> 1].
 
 Section FreeComAlgebraTheory.
 Variable (R : ComRings) (A : Sets).
 Implicit Types (x y : {freecalg R[A]}).
 
-Lemma freecalg1E : 1%R = [fm / 1%M |-> 1] :> {freecalg R[A]}.
+Lemma freecalg1E : 1%R = [ma / 1%M |-> 1] :> {freecalg R[A]}.
 Proof. by []. Qed.
 Lemma freecalgE x :
   \sum_(m <- finsupp x) x m *: \prod_(i <- enum_freecmon m) fcalg_gen R i = x.
@@ -2726,7 +2945,7 @@ Definition forget_ComAlgebra_to_ComSemirings :=
 
 Definition transf_ComAlgebra_to_multcmon :
   forget_ComAlgebras_to_Sets R ~> forgetCMult
-  := 
+  :=
   [NEq forget_ComMonoids_to_Sets \O forget_ComSemiRings_to_ComMonoids \O
          forget_ComAlgebra_to_ComSemirings,
        forgetCMult]
@@ -2736,7 +2955,7 @@ Definition transf_ComAlgebra_to_multcmon :
 
 Definition transf_multcmon_to_ComAlgebra :
   forgetCMult ~> forget_ComAlgebras_to_Sets R
-  := 
+  :=
   [NEq forget_ComSemiRings_to_Sets \O forget_ComAlgebra_to_ComSemirings,
        forget_ComAlgebras_to_Sets R]
     \v (transf_from_multcmon \h NId forget_ComAlgebra_to_ComSemirings)
@@ -2772,14 +2991,14 @@ Section UniversalProperty.
 
 Variable (R : ComRings).
 
-Variables (S : Sets) (A : ComAlgebras R)
-  (f : {hom[Sets] S -> forget_ComAlgebras_to_Sets R A}).
+Variables (E : Sets) (A : ComAlgebras R) (f : {hom[Sets] E -> A}).
 
 Let Adj := adjoint_FreeComAlgebra_forget_to_Sets R.
 
-Definition univmap_FreeComAlgebra := AdjointFunctors.hom_inv Adj f.
+Definition univmap_FreeComAlgebra :
+  {hom[ComAlgebras R] {freecalg R[E]} -> A} := AdjointFunctors.hom_inv Adj f.
 
-Lemma eta_FreeComAlgebraE i : AdjointFunctors.eta Adj S i = fcalg_gen R i.
+Lemma eta_FreeComAlgebraE i : AdjointFunctors.eta Adj E i = fcalg_gen R i.
 Proof.
 rewrite /= !HCompId /transf_from_multcmon /transf_from_multcmon_fun /=.
 by rewrite !HIdComp /= !HCompId.
@@ -2791,51 +3010,53 @@ rewrite -[RHS](AdjointFunctors.hom_invK Adj _ _ f i) /=; do 4 congr (_ _).
 by rewrite -eta_FreeComAlgebraE.
 Qed.
 
-Lemma univmap_FreeComAlgebra_uniq (g : {hom[ComAlgebras R] {freecalg R[S]} -> A}) :
-  (forall i : S, g (fcalg_gen R i) = f i) -> g =m= univmap_FreeComAlgebra.
+Lemma univmap_FreeComAlgebra_uniq (g : {hom[ComAlgebras R] {freecalg R[E]} -> A}) :
+  (forall e : E, g (fcalg_gen R e) = f e) -> g =m= univmap_FreeComAlgebra.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
-move=> i; rewrite AdjointFunctors.hom_invK -{}eq.
-by have /= -> := eta_FreeComAlgebraE i.
+move=> e; rewrite AdjointFunctors.hom_invK -{}eq.
+by have /= -> := eta_FreeComAlgebraE e.
 Qed.
 
 End UniversalProperty.
 
-Section FunctorialityInRing.
-Variable (R S : ComRings) (f : {rmorphism R -> S}) (A : Sets).
 
-Definition homRing_FreeComAlgebra : {freecalg R[A]} -> {freecalg S[A]} :=
-  @homRing_MonoidLAlgebra R S f (FreeComMonoid A).
+Section FunctorialityInRing.
+Variable (R S : ComRings) (f : {rmorphism R -> S}) (E : Sets).
+
+Definition homRing_FreeComAlgebra : {freecalg R[E]} -> {freecalg S[E]} :=
+  @homRing_MonoidLAlgebra R S f (FreeComMonoid E).
 HB.instance Definition _ := GRing.LRMorphism.on homRing_FreeComAlgebra.
 Lemma homRing_FreeComAlgebraP i :
   homRing_FreeComAlgebra (fcalg_gen R i) = (fcalg_gen S i).
 Proof. by rewrite /homRing_FreeComAlgebra homRing_MonoidLAlgebraP. Qed.
 Lemma homRing_FreeComAlgebra_uniq
-  (g : {lrmorphism {freecalg R[A]} -> {freecalg S[A]} | f \; *:%R }) :
-  (forall i, g (fcalg_gen R i) = fcalg_gen S i) -> g =m= homRing_FreeComAlgebra.
+  (g : {lrmorphism {freecalg R[E]} -> {freecalg S[E]} | f \; *:%R }) :
+  (forall e : E, g (fcalg_gen R e) = fcalg_gen S e)
+  -> g =m= homRing_FreeComAlgebra.
 Proof.
 move=> eqg x; rewrite -(freecalgE x).
-rewrite [LHS]linear_sum [RHS]linear_sum; apply: eq_bigr => i _.
-rewrite !linearZ_LR !rmorph_prod /=; congr (_ *: _); apply: eq_bigr => a _.
+rewrite [LHS]linear_sum [RHS]linear_sum; apply: eq_bigr => m _.
+rewrite !linearZ_LR !rmorph_prod /=; congr (_ *: _); apply: eq_bigr => e _.
 by rewrite eqg homRing_FreeComAlgebraP.
 Qed.
 
 End FunctorialityInRing.
 
 Section HomRingFreeComAlgebraFunctor.
-Variables (A : ComMonoids) (R S T : ComRings).
+Variables (E : Sets) (R S T : ComRings).
 
 Fact homRing_FreeComAlgebra_ext (f g : {rmorphism R -> S}) :
   f =m= g ->
-  homRing_FreeComAlgebra f (A := A) =m= homRing_FreeComAlgebra g (A := A).
+  homRing_FreeComAlgebra f (E := E) =m= homRing_FreeComAlgebra g (E := E).
 Proof. exact: homRing_FreeLModule_ext. Qed.
 Fact homRing_FreeComAlgebra_id :
-  homRing_FreeComAlgebra (A := A) (R := R) idfun =m= idfun.
+  homRing_FreeComAlgebra (E := E) (R := R) idfun =m= idfun.
 Proof. exact: homRing_FreeLModule_id. Qed.
 Fact homRing_FreeComAlgebra_comp
   (f : {rmorphism R -> S}) (g : {rmorphism S -> T}) :
-  homRing_FreeComAlgebra g (A := A) \@ homRing_FreeComAlgebra f (A := A)
-  =m= homRing_FreeComAlgebra (g \o f) (A := A).
+  homRing_FreeComAlgebra g (E := E) \@ homRing_FreeComAlgebra f (E := E)
+  =m= homRing_FreeComAlgebra (g \o f) (E := E).
 Proof. exact: homRing_FreeLModule_comp. Qed.
 
 End HomRingFreeComAlgebraFunctor.
@@ -2845,14 +3066,14 @@ Section RingUniversalProperty.
 
 Variable (R S : ComRings).
 
-Variables (X : Sets) (A : ComAlgebras S)
+Variables (E : Sets) (A : ComAlgebras S)
   (fR : {hom[ComRings] R -> S})
-  (fX : {hom[Sets] X -> forget_ComAlgebras_to_Sets S A}).
+  (fE : {hom[Sets] E -> forget_ComAlgebras_to_Sets S A}).
 
 Let fRm := rmorph_of_ComRing fR.
-Definition univmap_RingFreeComAlgebra : {freecalg R[X]} -> A :=
-  lrmorphism_of_ComAlgebras (@univmap_FreeComAlgebra S X A fX)
-    \o @homRing_FreeComAlgebra R S fRm X.
+Definition univmap_RingFreeComAlgebra : {freecalg R[E]} -> A :=
+  lrmorphism_of_ComAlgebras (@univmap_FreeComAlgebra S E A fE)
+    \o @homRing_FreeComAlgebra R S fRm E.
 HB.instance Definition _ := GRing.RMorphism.on univmap_RingFreeComAlgebra.
 Fact univmap_RingFreeComAlgebra_is_scalable :
   scalable_for (fRm \; *:%R) univmap_RingFreeComAlgebra.
@@ -2862,11 +3083,11 @@ rewrite /univmap_RingFreeComAlgebra => r x.
 by rewrite !compapp !linearZ_LR.
 Qed.
 HB.instance Definition _ :=
-  GRing.isScalable.Build R {freecalg R[X]} A (fRm \; *:%R)
+  GRing.isScalable.Build R {freecalg R[E]} A (fRm \; *:%R)
     univmap_RingFreeComAlgebra univmap_RingFreeComAlgebra_is_scalable.
 
 Lemma univmap_RingFreeComAlgebraP i :
-  univmap_RingFreeComAlgebra (fcalg_gen R i) = fX i.
+  univmap_RingFreeComAlgebra (fcalg_gen R i) = fE i.
 Proof.
 (* TODO : Big problem with locking *)
 rewrite /univmap_RingFreeComAlgebra !compapp homRing_FreeComAlgebraP.
@@ -2874,13 +3095,14 @@ exact: univmap_FreeComAlgebraP.
 Qed.
 
 Lemma univmap_RingFreeComAlgebra_uniq
-  (g : {lrmorphism {freecalg R[X]} -> A | fRm \; *:%R }) :
-  (forall i : X, g (fcalg_gen R i) = fX i) -> g =m= univmap_RingFreeComAlgebra.
+  (g : {lrmorphism {freecalg R[E]} -> A | fRm \; *:%R }) :
+  (forall e : E, g (fcalg_gen R e) = fE e)
+  -> g =m= univmap_RingFreeComAlgebra.
 Proof.
 move=> eqg a; rewrite -(freecalgE a).
 rewrite [LHS]linear_sum [RHS]linear_sum; apply eq_bigr => m _.
 rewrite !linearZ /=; congr (_ *: _).
-rewrite !rmorph_prod; apply: eq_bigr => {m} i _ /=.
+rewrite !rmorph_prod; apply: eq_bigr => {m} e _ /=.
 by rewrite eqg univmap_RingFreeComAlgebraP.
 Qed.
 

--- a/theories/algcat.v
+++ b/theories/algcat.v
@@ -722,7 +722,7 @@ Proof. by move=> /= a b f g eq y; rewrite /hom_FreeMonoid; exact: eq_map. Qed.
 Fact FreeMonoid_id : FunctorLaws.id FreeMonoid_mor.
 Proof. by move=> /= a x /=; rewrite /hom_FreeMonoid /= map_id. Qed.
 Fact FreeMonoid_comp  : FunctorLaws.comp FreeMonoid_mor.
-Proof. by move=> /= a b c f g x; rewrite /hom_FreeMonoid /= map_comp. Qed.
+Proof. by move=> /= a b c f g x; rewrite /= /hom_FreeMonoid -map_comp. Qed.
 Definition FreeMonoid T : Monoids := {freemon T}.
 HB.instance Definition _ :=
   @isFunctor.Build Sets Monoids
@@ -732,23 +732,23 @@ HB.instance Definition _ :=
 Module FreeMonoidAdjoint.
 Section Adjoint.
 
-Definition eta : FId ~~> forget_Monoids_to_Sets \o FreeMonoid :=
+Definition eta : FId ~~> forget_Monoids_to_Sets \O FreeMonoid :=
   fun a => [hom fun x : a => [fmon x]].
-Fact eta_natural : naturality FId (forget_Monoids_to_Sets \o FreeMonoid) eta.
+Fact eta_natural : naturality FId (forget_Monoids_to_Sets \O FreeMonoid) eta.
 Proof. by move=> /= a b h x /=; rewrite FIdf. Qed.
 HB.instance Definition _ :=
   @isNatural.Build Sets Sets FId
-    (forget_Monoids_to_Sets \o FreeMonoid) eta eta_natural.
+    (forget_Monoids_to_Sets \O FreeMonoid) eta eta_natural.
 
-Definition eps_fun T (m : (FreeMonoid \o forget_Monoids_to_Sets) T) : T :=
+Definition eps_fun T (m : (FreeMonoid \O forget_Monoids_to_Sets) T) : T :=
       \prod_(i <- m : {freemon _}) i.
 Fact eps_fun_monmorphism T : monmorphism (@eps_fun T).
 Proof. by rewrite /eps_fun; split => [|s t]; rewrite ?big_nil ?big_cat. Qed.
 HB.instance Definition _ T :=
-  isHom.Build Monoids ((FreeMonoid \o forget_Monoids_to_Sets) T) (FId T)
+  isHom.Build Monoids ((FreeMonoid \O forget_Monoids_to_Sets) T) (FId T)
     (@eps_fun T) (@eps_fun_monmorphism T).
-Definition eps : FreeMonoid \o forget_Monoids_to_Sets ~~> FId := eps_fun.
-Fact eps_natural : naturality (FreeMonoid \o forget_Monoids_to_Sets) FId eps.
+Definition eps : FreeMonoid \O forget_Monoids_to_Sets ~~> FId := eps_fun.
+Fact eps_natural : naturality (FreeMonoid \O forget_Monoids_to_Sets) FId eps.
 Proof.
 move=> /= a b h x /=.
 rewrite -!mmorphism_of_MonoidsE [LHS]mmorph_prod /=.
@@ -756,7 +756,7 @@ by rewrite FIdf /eps_fun /= /hom_FreeMonoid big_map.
 Qed.
 HB.instance Definition _ :=
   @isNatural.Build Monoids Monoids
-    (FreeMonoid \o forget_Monoids_to_Sets) FId eps eps_natural.
+    (FreeMonoid \O forget_Monoids_to_Sets) FId eps eps_natural.
 
 Fact triL : TriangularLaws.left eta eps.
 Proof.
@@ -783,10 +783,10 @@ Let Adj := adjoint_FreeMonoid_forget_to_Sets.
 Definition univmap_FreeMonoid := AdjointFunctors.hom_inv Adj f.
 
 Lemma univmap_FreeMonoidP a : univmap_FreeMonoid [fmon a] = f a.
-Proof. by rewrite -[RHS](AdjointFunctors.hom_invK Adj). Qed.
+Proof. exact: (AdjointFunctors.hom_invK Adj). Qed.
 
 Lemma univmap_FreeMonoid_uniq (g : {hom[Monoids] {freemon A} -> M}) :
-  (forall a : A, g [fmon a] = f a) -> g =1 univmap_FreeMonoid.
+  (forall a : A, g [fmon a] = f a) -> g =m= univmap_FreeMonoid.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
 by move=> a; rewrite AdjointFunctors.hom_invK -{}eq.
@@ -1051,9 +1051,9 @@ Section IsoMC.
 
 Variable M : NModules.
 Definition isoMC_map : MC M -> FId M :=
-  (@commonoid_of_nmod_inv _) \o (@nmod_of_commonoid_inv (ComMonoid_of_NMod M)).
+  (@commonoid_of_nmod_inv _) \@ (@nmod_of_commonoid_inv (ComMonoid_of_NMod M)).
 Definition isoMC_inv : FId M -> MC M :=
-  (@nmod_of_commonoid _) \o (@commonoid_of_nmod M).
+  (@nmod_of_commonoid _) \@ (@commonoid_of_nmod M).
 
 Fact isoMC_mapK : cancel isoMC_map isoMC_inv.
 Proof.
@@ -1231,6 +1231,7 @@ Proof. by move=> /= a x /=; rewrite /hom_mset /= msetE. Qed.
 Fact FreeNModule_comp  : FunctorLaws.comp FreeNModule_mor.
 Proof.
 move=> /= a b c f g.
+rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!additive_of_NmodE; apply: additive_msetE => /= x.
 by rewrite /hom_mset /= !big_msetn.
 Qed.
@@ -1245,15 +1246,15 @@ Section Adjoint.
 Implicit Types (a : Sets) (T : NModules).
 
 Definition eta_fun a (x : a) := [mset x].
-Definition eta : FId ~~> forget_NModules_to_Sets \o FreeNModule := eta_fun.
+Definition eta : FId ~~> forget_NModules_to_Sets \O FreeNModule := eta_fun.
 Fact eta_natural :
-  naturality FId (forget_NModules_to_Sets \o FreeNModule) eta.
+  naturality FId (forget_NModules_to_Sets \O FreeNModule) eta.
 Proof. by move=> /= a b h x /=; rewrite /eta_fun FIdf hom_mset1. Qed.
 HB.instance Definition _ :=
   @isNatural.Build Sets Sets FId
-    (forget_NModules_to_Sets \o FreeNModule) eta eta_natural.
+    (forget_NModules_to_Sets \O FreeNModule) eta eta_natural.
 
-Let eps_fun T (m : (FreeNModule \o forget_NModules_to_Sets) T) : T :=
+Let eps_fun T (m : (FreeNModule \O forget_NModules_to_Sets) T) : T :=
       \sum_(i <- m : {mset _}) i.
 Fact eps_fun_nmod_morphism T : nmod_morphism (@eps_fun T).
 Proof.
@@ -1261,23 +1262,25 @@ rewrite /eps_fun; split => [|/= s t]; first by rewrite big_mset0.
 by rewrite big_msetD.
 Qed.
 HB.instance Definition _ T :=
-  isHom.Build NModules ((FreeNModule \o forget_NModules_to_Sets) T) (FId T)
+  isHom.Build NModules ((FreeNModule \O forget_NModules_to_Sets) T) (FId T)
     (@eps_fun T) (@eps_fun_nmod_morphism T).
-Definition eps : FreeNModule \o forget_NModules_to_Sets ~~> FId := eps_fun.
+Definition eps : FreeNModule \O forget_NModules_to_Sets ~~> FId := eps_fun.
 Fact eps_natural :
-  naturality (FreeNModule \o forget_NModules_to_Sets) FId eps.
+  naturality (FreeNModule \O forget_NModules_to_Sets) FId eps.
 Proof.
 move=> /= a b h.
+rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!additive_of_NmodE; apply: additive_msetE => /= x.
 by rewrite FIdf /eps_fun /hom_mset /= !big_msetn.
 Qed.
 HB.instance Definition _ :=
   @isNatural.Build NModules NModules
-    (FreeNModule \o forget_NModules_to_Sets) FId eps eps_natural.
+    (FreeNModule \O forget_NModules_to_Sets) FId eps eps_natural.
 
 Fact triL : TriangularLaws.left eta eps.
 Proof.
 move=> /= a.
+rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!additive_of_NmodE; apply: additive_msetE => /= x.
 by rewrite /eta_fun /= /eps_fun /hom_mset /= !big_msetn.
 Qed.
@@ -1301,10 +1304,10 @@ Let Adj := adjoint_FreeNModule_forget_to_Sets.
 Definition univmap_FreeNModule := AdjointFunctors.hom_inv Adj f.
 
 Lemma univmap_FreeNModuleP a : univmap_FreeNModule [mset a] = f a.
-Proof. by rewrite -[RHS](AdjointFunctors.hom_invK Adj). Qed.
+Proof. exact: (AdjointFunctors.hom_invK Adj). Qed.
 
 Lemma univmap_FreeNModule_uniq (g : {hom[NModules] {mset A} -> M}) :
-  (forall a : A, g [mset a] = f a) -> g =1 univmap_FreeNModule.
+  (forall a : A, g [mset a] = f a) -> g =m= univmap_FreeNModule.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
 by move=> a; rewrite AdjointFunctors.hom_invK -{}eq.
@@ -1414,13 +1417,13 @@ Definition univmap_FreeComMonoid := AdjointFunctors.hom_inv Adj f.
 Lemma univmap_FreeComMonoidP a :
   univmap_FreeComMonoid (cmon_gen a) = f a.
 Proof.
-rewrite -[RHS](AdjointFunctors.hom_invK Adj) /=; repeat congr (_ _).
+rewrite -[RHS](AdjointFunctors.hom_invK Adj _ _ f a) /=; repeat congr (_ _).
 (* TODO: I'm reproving some cancellation here *)
 by rewrite !HCompId /= !HIdComp.
 Qed.
 
 Lemma univmap_FreeComMonoid_uniq (g : {hom[ComMonoids] {freecmon A} -> M}) :
-  (forall a : A, g (cmon_gen a) = f a) -> g =1 univmap_FreeComMonoid.
+  (forall a : A, g (cmon_gen a) = f a) -> g =m= univmap_FreeComMonoid.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
 move=> a; rewrite AdjointFunctors.hom_invK -{}eq.
@@ -1442,7 +1445,7 @@ Variable R : nzRingType.
 
 Lemma FreeLModuleE (a : Sets) (T : LModules R)
   (f g : {hom[LModules R] {freemod R[a]} -> T}) :
-  (forall x : a, f [fm / x |-> 1] = g [fm / x |-> 1]) -> f =1 g.
+  (forall x : a, f [fm / x |-> 1] = g [fm / x |-> 1]) -> f =m= g.
 Proof.
 move=> eq x; rewrite -(linear_of_LmodE f) -(linear_of_LmodE g).
 exact: linear_fmE.
@@ -1500,6 +1503,7 @@ Qed.
 Fact FreeLModule_comp  : FunctorLaws.comp FreeLModule_mor.
 Proof.
 move=> /= a b c f g.
+rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!linear_of_LmodE; apply: linear_fmE => /= x.
 by rewrite /hom_flm /= !(finsupp_fm1, big_seq_fset1, fm1E, eqxx).
 Qed.
@@ -1550,6 +1554,7 @@ Definition eps : fm \o forgetf ~~> FId := eps_fun.
 Fact eps_natural : naturality (fm \o forgetf) FId eps.
 Proof.
 move=> /= a b h.
+rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!linear_of_LmodE; apply: linear_fmE => /= x.
 rewrite FIdf /eps_fun /= hom_flm1.
 by rewrite !finsupp_fm1 !big_seq_fset1 !fm1E !eqxx !scale1r.
@@ -1561,6 +1566,7 @@ HB.instance Definition _ :=
 Fact triL : TriangularLaws.left eta eps.
 Proof.
 move=> /= a.
+rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!linear_of_LmodE; apply: linear_fmE => /= x.
 rewrite /eta_fun /= /eps_fun /= hom_flm1.
 by rewrite !finsupp_fm1 !big_seq_fset1 !fm1E !eqxx !scale1r.
@@ -1589,10 +1595,10 @@ Let Adj := (adjoint_FreeLModule_forget_to_Sets R).
 Definition univmap_FreeLModule := AdjointFunctors.hom_inv Adj f.
 
 Lemma univmap_FreeLModuleP a : univmap_FreeLModule [fm / a |-> 1] = f a.
-Proof. by rewrite -[RHS](AdjointFunctors.hom_invK Adj). Qed.
+Proof. by rewrite -[RHS](AdjointFunctors.hom_invK Adj _ _ f a). Qed.
 
 Lemma univmap_FreeLModule_uniq (g : {hom[LModules R] {freemod R[A]} -> M}) :
-  (forall a : A, g [fm / a |-> 1] = f a) -> g =1 univmap_FreeLModule.
+  (forall a : A, g [fm / a |-> 1] = f a) -> g =m= univmap_FreeLModule.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
 by move=> a; rewrite AdjointFunctors.hom_invK -{}eq.
@@ -1649,7 +1655,7 @@ HB.instance Definition _ :=
 
 Lemma homRing_FreeLModule_uniq
   (g : {linear {freemod R[A]} -> {freemod S[A]} | f \; *:%R}) :
-  (forall a, g [fm / a |-> 1] = [fm / a |-> 1]) -> g =1 homRing_FreeLModule.
+  (forall a, g [fm / a |-> 1] = [fm / a |-> 1]) -> g =m= homRing_FreeLModule.
 Proof.
 move=> eq; apply: linear_fm_scaleE => //= x.
 by rewrite eq homRing_FreeLModuleP.
@@ -1675,14 +1681,14 @@ Qed.
 
 Variables (f : {rmorphism R -> S}) (g : {rmorphism S -> T}).
 
-Let comp := homRing_FreeLModule g (A := A) \o homRing_FreeLModule f (A := A).
+Let comp := homRing_FreeLModule g (A := A) \@ homRing_FreeLModule f (A := A).
 HB.instance Definition _ := GRing.Additive.on comp.
 Let comp_is_scalable : scalable_for (g \o f \; *:%R) comp.
 Proof. by rewrite /comp => r x /=; rewrite !linearZ_LR /=. Qed.
 HB.instance Definition _ :=
   GRing.isScalable.Build R {freemod R[A]} {freemod T[A]}
     (g \o f \; *:%R) comp comp_is_scalable.
-Fact homRing_FreeLModule_comp : comp =1 homRing_FreeLModule (g \o f) (A := A).
+Fact homRing_FreeLModule_comp : comp =m= homRing_FreeLModule (g \o f) (A := A).
 Proof.
 apply: linear_fm_scaleE => //= x.
 by rewrite /comp /= !homRing_FreeLModuleP.
@@ -1699,7 +1705,7 @@ HB.instance Definition _ (R S : pzSemiRingType) (f : {rmorphism R -> S}) :=
     (multMon_mor f : (_ : Monoids) -> _) (multMon_mor_monmorphism f).
 Definition functor_multMon_fun (R : SemiRings) : Monoids := multMon R.
 Fact multMon_ext : FunctorLaws.ext (C := SemiRings) multMon_mor.
-Proof. by move=> /= a b f g eq y; rewrite /multMon_mor /= eq. Qed.
+Proof. by move=> /= a b f g eq y; rewrite /= /multMon_mor /= eq. Qed.
 Fact multMon_id : FunctorLaws.id (C := SemiRings) multMon_mor.
 Proof. by move=> /= a x /=; rewrite /multMon_mor /=; exact: val_inj. Qed.
 Fact multMon_comp  : FunctorLaws.comp (C := SemiRings) multMon_mor.
@@ -1746,7 +1752,7 @@ Proof. by []. Qed.
 
 (** Fix the non HB forgetful inheritance SemiRings -> Monoids *)
 Local Notation multSet :=  (* Multiplicative forgetful Sets of a SemiRings *)
-  (forget_Monoids_to_Sets \o forget_SemiRings_to_Monoids).
+  (forget_Monoids_to_Sets \O forget_SemiRings_to_Monoids).
 
 Section FixForgetMultMon.
 Variable (R : SemiRings).
@@ -1807,10 +1813,9 @@ Implicit Types (r s : R) (a b c : A) (x y z : {monalg R[A]}).
 Definition one_ma : {monalg R[A]} := [fm / 1 |-> 1].
 Definition mul_mma a : {hom[LModules R] {monalg R[A]} -> {monalg R[A]}} :=
   (@FreeLModule R) # [the {hom[Sets] A -> A} of *%M a].
-Lemma mul_mma_comp a b : mul_mma b \o mul_mma a =1 mul_mma (b * a).
+Lemma mul_mma_comp a b : mul_mma b \@ mul_mma a =m= mul_mma (b * a).
 Proof.
-rewrite /mul_mma => c.
-rewrite -[LHS](functor_o (F := FreeLModule R)).
+rewrite /mul_mma -(functor_o (FreeLModule R)).
 apply: (functor_ext_hom (FreeLModule R)).
 by move=> {}c /=; rewrite mulmA.
 Qed.
@@ -2029,16 +2034,16 @@ Section HomRingMonoidLAlgebraFunctor.
 Variables (A : Monoids) (R S T : Rings).
 
 Fact homRing_MonoidLAlgebra_ext (f g : {rmorphism R -> S}) :
-  f =1 g
-  -> homRing_MonoidLAlgebra f (A := A) =1 homRing_MonoidLAlgebra g (A := A).
+  f =m= g
+  -> homRing_MonoidLAlgebra f (A := A) =m= homRing_MonoidLAlgebra g (A := A).
 Proof. exact: homRing_FreeLModule_ext. Qed.
 Fact homRing_MonoidLAlgebra_id :
-  homRing_MonoidLAlgebra (A := A) (R := R) idfun =1 idfun.
+  homRing_MonoidLAlgebra (A := A) (R := R) idfun =m= idfun.
 Proof. exact: homRing_FreeLModule_id. Qed.
 Fact homRing_MonoidLAlgebra_comp
   (f : {rmorphism R -> S}) (g : {rmorphism S -> T}) :
-  homRing_MonoidLAlgebra g (A := A) \o homRing_MonoidLAlgebra f (A := A)
-  =1 homRing_MonoidLAlgebra (g \o f) (A := A).
+  homRing_MonoidLAlgebra g (A := A) \@ homRing_MonoidLAlgebra f (A := A)
+  =m= homRing_MonoidLAlgebra (g \o f) (A := A).
 Proof. exact: homRing_FreeLModule_comp. Qed.
 
 End HomRingMonoidLAlgebraFunctor.
@@ -2114,30 +2119,30 @@ Local Notation fMA := (MonoidAlgebra R).
 Section def_ETA.
 Variable A : Monoids.
 
-Definition eta_fun (a : A) : (forgetf \o fMA) A := @to_multMon _ [fm / a |-> 1].
+Definition eta_fun (a : A) : (forgetf \O fMA) A := @to_multMon _ [fm / a |-> 1].
 Fact eta_fun_monmorphism : monmorphism eta_fun.
 Proof.
 split => //; rewrite /eta_fun => a b.
 by rewrite monME mulmacE mulr1.
 Qed.
 HB.instance Definition _ :=
-  isHom.Build Monoids A ((forgetf \o fMA) A) eta_fun eta_fun_monmorphism.
+  isHom.Build Monoids A ((forgetf \O fMA) A) eta_fun eta_fun_monmorphism.
 
 End def_ETA.
 
-Definition eta : FId ~~> forgetf \o fMA := eta_fun.
-Fact eta_natural : naturality FId (forgetf \o fMA) eta.
+Definition eta : FId ~~> forgetf \O fMA := eta_fun.
+Fact eta_natural : naturality FId (forgetf \O fMA) eta.
 Proof.
 move=> /= A B h x /=; rewrite FIdf /eta_fun /=.
 by rewrite /multMon_mor /= /hom_MonoidAlgebra univmap_FreeLModuleP.
 Qed.
 HB.instance Definition _ :=
-  @isNatural.Build Monoids Monoids FId (forgetf \o fMA) eta eta_natural.
+  @isNatural.Build Monoids Monoids FId (forgetf \O fMA) eta eta_natural.
 
 Section def_EPS.
 Variable T : Algebras R.
 
-Definition eps_fun (m : (fMA \o forgetf) T) : T :=
+Definition eps_fun (m : (fMA \O forgetf) T) : T :=
   (\sum_(i <- finsupp (m : {freemod R[_]})) (m i *: \val i)).
 
 Lemma eps_fun1E t r : eps_fun [fm / t |-> r] = r *: \val t.
@@ -2165,7 +2170,7 @@ rewrite -big_split /=; apply: eq_bigr => a _.
   by rewrite mulr0 addr0.
 Qed.
 HB.instance Definition _ :=
-  GRing.isLinear.Build R ((fMA \o forgetf) T) T _ eps_fun eps_fun_linear.
+  GRing.isLinear.Build R ((fMA \O forgetf) T) T _ eps_fun eps_fun_linear.
 
 Fact eps_fun_is_lalg_morphism : lalg_morphism eps_fun.
 Proof.
@@ -2179,13 +2184,13 @@ rewrite mulmacE !eps_fun1E /=.
 by rewrite -!scalerAr -!scalerAl scalerA mulrC.
 Qed.
 HB.instance Definition _ :=
-  isHom.Build (Algebras R) ((fMA \o forgetf) T) T
+  isHom.Build (Algebras R) ((fMA \O forgetf) T) T
     eps_fun eps_fun_is_lalg_morphism.
 
 End def_EPS.
 
-Definition eps : fMA \o forgetf ~~> FId := eps_fun.
-Fact eps_natural : naturality (fMA \o forgetf) FId eps.
+Definition eps : fMA \O forgetf ~~> FId := eps_fun.
+Fact eps_natural : naturality (fMA \O forgetf) FId eps.
 Proof.
 move=> /= A B h x /=; rewrite FIdf -(fmE x); move: (finsupp x) => S.
 rewrite [eps_fun _]linear_sum /= -lrmorphism_of_AlgebrasE [LHS]linear_sum.
@@ -2199,11 +2204,12 @@ have /= -> := forget_Algebras_to_LAlgebrasE h.
 by rewrite -!lrmorphism_of_AlgebrasE linearZ.
 Qed.
 HB.instance Definition _ :=
-  @isNatural.Build (Algebras R) (Algebras R) (fMA \o forgetf) FId eps eps_natural.
+  @isNatural.Build (Algebras R) (Algebras R) (fMA \O forgetf) FId eps eps_natural.
 
 Fact triL : TriangularLaws.left eta eps.
 Proof.
 move=> /= a.
+rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -linear_of_LmodE; apply: linear_fmE => x /=.
 rewrite -[X in eps_fun X]/(univmap_FreeLModule _ _) univmap_FreeLModuleP /=.
 by rewrite /eta_fun /= eps_fun1E scale1r /=.
@@ -2233,7 +2239,7 @@ Let Adj := adjoint_MonoidAlgebra_forget_to_Monoids R.
 Definition univmap_MonoidAlgebra := AdjointFunctors.hom_inv Adj f.
 
 Lemma univmap_MonoidAlgebraP a : univmap_MonoidAlgebra [fm / a |-> 1] = \val (f a).
-Proof. by rewrite -[in RHS](AdjointFunctors.hom_invK Adj). Qed.
+Proof. by rewrite -[in RHS](AdjointFunctors.hom_invK Adj _ _ f a). Qed.
 
 Lemma univmap_MonoidAlgebra_uniq (g : {hom[Algebras R] {monalg R[A]} -> M}) :
   (forall a : A, g [fm / a |-> 1] = \val (f a)) -> g =1 univmap_MonoidAlgebra.
@@ -2335,18 +2341,18 @@ Definition univmap_FreeAlgebra := AdjointFunctors.hom_inv Adj f.
 
 Lemma univmap_FreeAlgebraP i : univmap_FreeAlgebra (falg_gen i) = f i.
 Proof.
-rewrite -[RHS](AdjointFunctors.hom_invK Adj) /=; repeat congr (_ _).
-by rewrite !HCompId /= HIdComp.
+rewrite -[RHS](AdjointFunctors.hom_invK Adj _ _ f i) /=; repeat congr (_ _).
+by rewrite !HCompId /= !HIdComp /= HCompId.
 Qed.
 
 Lemma eta_FreeAlgebraE i : AdjointFunctors.eta Adj S i = falg_gen i.
 Proof.
 rewrite /= !HCompId /transf_from_multmon /transf_from_multmon_fun /=.
-by rewrite HIdComp /=.
+by rewrite HIdComp /= HCompId.
 Qed.
 
 Lemma univmap_FreeAlgebra_uniq (g : {hom[Algebras R] {freealg R[S]} -> A}) :
-  (forall i : S, g (falg_gen i) = f i) -> g =1 univmap_FreeAlgebra.
+  (forall i : S, g (falg_gen i) = f i) -> g =m= univmap_FreeAlgebra.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
 move=> i; rewrite AdjointFunctors.hom_invK -{}eq.
@@ -2369,7 +2375,7 @@ Proof. by rewrite /homRing_FreeAlgebra homRing_MonoidLAlgebraP. Qed.
 Lemma homRing_FreeAlgebra_uniq
   (g : {lrmorphism {freealg R[A]} -> {freealg S[A]} | f \; *:%R }) :
   (forall i, g (falg_gen i) = falg_gen i) ->
-  g =1 homRing_FreeAlgebra.
+  g =m= homRing_FreeAlgebra.
 Proof.
 move=> eq; apply: homRing_MonoidLAlgebra_uniq => /= a.
 rewrite -!/[fm / _ |-> _] -(freemonE a) !prodmaE rmorph_prod.
@@ -2382,15 +2388,15 @@ Section HomRingFreeAlgebraFunctor.
 Variables (A : Monoids) (R S T : ComRings).
 
 Fact homRing_FreeAlgebra_ext (f g : {rmorphism R -> S}) :
-  f =1 g -> homRing_FreeAlgebra f (A := A) =1 homRing_FreeAlgebra g (A := A).
+  f =m= g -> homRing_FreeAlgebra f (A := A) =m= homRing_FreeAlgebra g (A := A).
 Proof. exact: homRing_FreeLModule_ext. Qed.
 Fact homRing_FreeAlgebra_id :
-  homRing_FreeAlgebra (A := A) (R := R) idfun =1 idfun.
+  homRing_FreeAlgebra (A := A) (R := R) idfun =m= idfun.
 Proof. exact: homRing_FreeLModule_id. Qed.
 Fact homRing_FreeAlgebra_comp
   (f : {rmorphism R -> S}) (g : {rmorphism S -> T}):
-  homRing_FreeAlgebra g (A := A) \o homRing_FreeAlgebra f (A := A)
-  =1 homRing_FreeAlgebra (g \o f) (A := A).
+  homRing_FreeAlgebra g (A := A) \@ homRing_FreeAlgebra f (A := A)
+  =m= homRing_FreeAlgebra (g \o f) (A := A).
 Proof. exact: homRing_FreeLModule_comp. Qed.
 
 End HomRingFreeAlgebraFunctor.
@@ -2488,26 +2494,26 @@ Local Notation fMA := (ComMonoidAlgebra R).
 Section def_ETA.
 Variable A : ComMonoids.
 
-Definition eta_fun (a : A) : (forgetf \o fMA) A := @to_multMon _ [fm / a |-> 1].
+Definition eta_fun (a : A) : (forgetf \O fMA) A := @to_multMon _ [fm / a |-> 1].
 Fact eta_fun_monmorphism : monmorphism eta_fun.
 Proof.
 split => //; rewrite /eta_fun => a b.
 by rewrite monME mulmacE mulr1.
 Qed.
 HB.instance Definition _ :=
-  isHom.Build ComMonoids A ((forgetf \o fMA) A) eta_fun eta_fun_monmorphism.
+  isHom.Build ComMonoids A ((forgetf \O fMA) A) eta_fun eta_fun_monmorphism.
 
 End def_ETA.
 
-Definition eta : FId ~~> forgetf \o fMA := eta_fun.
-Fact eta_natural : naturality FId (forgetf \o fMA) eta.
+Definition eta : FId ~~> forgetf \O fMA := eta_fun.
+Fact eta_natural : naturality FId (forgetf \O fMA) eta.
 Proof.
 move=> /= A B h x /=; rewrite FIdf /eta_fun /=.
 rewrite /ForgetSemiRings_to_Monoids.multComMon_mor /multMon_mor.
 by rewrite /= /hom_MonoidAlgebra univmap_FreeLModuleP.
 Qed.
 HB.instance Definition _ :=
-  @isNatural.Build ComMonoids ComMonoids FId (forgetf \o fMA) eta eta_natural.
+  @isNatural.Build ComMonoids ComMonoids FId (forgetf \O fMA) eta eta_natural.
 
 Section def_EPS.
 Variable T : ComAlgebras R.
@@ -2580,6 +2586,7 @@ HB.instance Definition _ :=
 Fact triL : TriangularLaws.left eta eps.
 Proof.
 move=> /= a.
+rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -linear_of_LmodE; apply: linear_fmE => x /=.
 rewrite -[X in eps_fun X]/(univmap_FreeLModule _ _) univmap_FreeLModuleP /=.
 by rewrite /eta_fun /= eps_fun1E scale1r /=.
@@ -2612,10 +2619,10 @@ Definition univmap_ComMonoidAlgebra := AdjointFunctors.hom_inv Adj f.
 
 Lemma univmap_ComMonoidAlgebraP a :
   univmap_ComMonoidAlgebra [fm / a |-> 1] = \val (f a).
-Proof. by rewrite -[in RHS](AdjointFunctors.hom_invK Adj). Qed.
+Proof. by rewrite -[in RHS](AdjointFunctors.hom_invK Adj _ _ f a). Qed.
 
 Lemma univmap_ComMonoidAlgebra_uniq (g : {hom[ComAlgebras R] {monalg R[A]} -> M}) :
-  (forall a : A, g [fm / a |-> 1] = \val (f a)) -> g =1 univmap_ComMonoidAlgebra.
+  (forall a : A, g [fm / a |-> 1] = \val (f a)) -> g =m= univmap_ComMonoidAlgebra.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
 move=> a; rewrite AdjointFunctors.hom_invK.
@@ -2726,10 +2733,10 @@ Definition transf_multcmon_to_ComAlgebra :
               forget_ComAlgebra_to_ComSemirings].
 
 Lemma transf_ComAlgebra_to_multcmonE A :
-  transf_ComAlgebra_to_multcmon A =1 transf_to_multcmon A.
+  transf_ComAlgebra_to_multcmon A =m= transf_to_multcmon A.
 Proof. by move=> a; rewrite /= !HCompId. Qed.
 Lemma transf_multcmon_to_ComAlgebraE A :
-  transf_multcmon_to_ComAlgebra A =1 transf_from_multcmon A.
+  transf_multcmon_to_ComAlgebra A =m= transf_from_multcmon A.
 Proof. by move=> a; rewrite /= !HCompId. Qed.
 Lemma transf_ComAlgebra_to_multcmonK A :
   cancel (transf_ComAlgebra_to_multcmon A) (transf_multcmon_to_ComAlgebra A).
@@ -2763,17 +2770,17 @@ Definition univmap_FreeComAlgebra := AdjointFunctors.hom_inv Adj f.
 Lemma eta_FreeComAlgebraE i : AdjointFunctors.eta Adj S i = fcalg_gen R i.
 Proof.
 rewrite /= !HCompId /transf_from_multcmon /transf_from_multcmon_fun /=.
-by rewrite !HIdComp /=.
+by rewrite !HIdComp /= !HCompId.
 Qed.
 
 Lemma univmap_FreeComAlgebraP i : univmap_FreeComAlgebra (fcalg_gen R i) = f i.
 Proof.
-rewrite -[RHS](AdjointFunctors.hom_invK Adj) /=; do 4 congr (_ _).
+rewrite -[RHS](AdjointFunctors.hom_invK Adj _ _ f i) /=; do 4 congr (_ _).
 by rewrite -eta_FreeComAlgebraE.
 Qed.
 
 Lemma univmap_FreeComAlgebra_uniq (g : {hom[ComAlgebras R] {freecalg R[S]} -> A}) :
-  (forall i : S, g (fcalg_gen R i) = f i) -> g =1 univmap_FreeComAlgebra.
+  (forall i : S, g (fcalg_gen R i) = f i) -> g =m= univmap_FreeComAlgebra.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
 move=> i; rewrite AdjointFunctors.hom_invK -{}eq.
@@ -2793,7 +2800,7 @@ Lemma homRing_FreeComAlgebraP i :
 Proof. by rewrite /homRing_FreeComAlgebra homRing_MonoidLAlgebraP. Qed.
 Lemma homRing_FreeComAlgebra_uniq
   (g : {lrmorphism {freecalg R[A]} -> {freecalg S[A]} | f \; *:%R }) :
-  (forall i, g (fcalg_gen R i) = fcalg_gen S i) -> g =1 homRing_FreeComAlgebra.
+  (forall i, g (fcalg_gen R i) = fcalg_gen S i) -> g =m= homRing_FreeComAlgebra.
 Proof.
 move=> eqg x; rewrite -(freecalgE x) !linear_sum; apply: eq_bigr => i _.
 rewrite !linearZ_LR !rmorph_prod /=; congr (_ *: _); apply: eq_bigr => a _.
@@ -2806,15 +2813,16 @@ Section HomRingFreeComAlgebraFunctor.
 Variables (A : ComMonoids) (R S T : ComRings).
 
 Fact homRing_FreeComAlgebra_ext (f g : {rmorphism R -> S}) :
-  f =1 g -> homRing_FreeComAlgebra f (A := A) =1 homRing_FreeComAlgebra g (A := A).
+  f =m= g ->
+  homRing_FreeComAlgebra f (A := A) =m= homRing_FreeComAlgebra g (A := A).
 Proof. exact: homRing_FreeLModule_ext. Qed.
 Fact homRing_FreeComAlgebra_id :
-  homRing_FreeComAlgebra (A := A) (R := R) idfun =1 idfun.
+  homRing_FreeComAlgebra (A := A) (R := R) idfun =m= idfun.
 Proof. exact: homRing_FreeLModule_id. Qed.
 Fact homRing_FreeComAlgebra_comp
   (f : {rmorphism R -> S}) (g : {rmorphism S -> T}) :
-  homRing_FreeComAlgebra g (A := A) \o homRing_FreeComAlgebra f (A := A)
-  =1 homRing_FreeComAlgebra (g \o f) (A := A).
+  homRing_FreeComAlgebra g (A := A) \@ homRing_FreeComAlgebra f (A := A)
+  =m= homRing_FreeComAlgebra (g \o f) (A := A).
 Proof. exact: homRing_FreeLModule_comp. Qed.
 
 End HomRingFreeComAlgebraFunctor.
@@ -2854,7 +2862,7 @@ Qed.
 
 Lemma univmap_RingFreeComAlgebra_uniq
   (g : {lrmorphism {freecalg R[X]} -> A | fRm \; *:%R }) :
-  (forall i : X, g (fcalg_gen R i) = fX i) -> g =1 univmap_RingFreeComAlgebra.
+  (forall i : X, g (fcalg_gen R i) = fX i) -> g =m= univmap_RingFreeComAlgebra.
 Proof.
 move=> eqg a; rewrite -(freecalgE a) !linear_sum; apply eq_bigr => m _.
 rewrite !linearZ /=; congr (_ *: _).

--- a/theories/algcat.v
+++ b/theories/algcat.v
@@ -168,14 +168,26 @@ Adjunction of functors:
 
 Equivalence of categories:
 
-- equivalence_ComMonoids_NModules : through the functors
-  NMod_of_ComMonoid and ComMonoid_of_NMod
+The categories ComMonoids and NModules are adjoint equivalent through
+the functors NModule_of_ComMonoid and ComMonoid_of_NModule as witnessed by
+equivalence_ComMonoids_NModules with the adjunctions
+adjoint_ComMonoid_NModule and adjoint_NModule_ComMonoid.
+
+- cmon_of_nmod x == the image in ComMonoid_of_NModule M of an element x
+                   of a N-module M
+- cmon_of_nmod_inv y == the preimage in M of an element y of
+                   ComMonoid_of_NModule M
+- nmod_of_cmon x == the image in NModule_of_ComMonoid M of an element x
+                   of a commmutative monoid M
+- nmod_of_cmon_inv x == the preimage in M of an element y of
+                   NModule_of_ComMonoid M
 
 Finaly the following useful notion are defined:
 
-- setHom f     == the Sets morphism associated to the function f.
-
-
+- setHom f      == the Sets morphism associated to the function f.
+- [fmon x]      == the image of x : T in the free monoid {freemon T}
+- [ma / x |-> v] == the element of {monalg R[M]} whose support is x with
+                  coefficient c
 *)
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
@@ -863,12 +875,12 @@ Proof. by []. Qed.
 Local Open Scope monoid_scope.
 
 
-Definition FreeMonoidT (a : Sets) := seq a.
-HB.instance Definition _ (a : Sets) := Choice.on (FreeMonoidT a).
+Definition FreeMonoid_obj (a : Sets) := seq a.
+HB.instance Definition _ (a : Sets) := Choice.on (FreeMonoid_obj a).
 HB.instance Definition _ (a : Sets) :=
-  isMonoid.Build (FreeMonoidT a) (@catA a) (@cat0s a) (@cats0 a).
+  isMonoid.Build (FreeMonoid_obj a) (@catA a) (@cat0s a) (@cats0 a).
 
-Notation "{ 'freemon' T }" := (FreeMonoidT T)
+Notation "{ 'freemon' T }" := (FreeMonoid_obj T)
                                 (at level 0, format "{ 'freemon'  T }").
 Notation "[fmon x ]" := ([:: x] : {freemon _})
                         (at level 0, format "[fmon  x ]").
@@ -882,36 +894,35 @@ Section FreeMonoid.
 
 Variables (a b c : Sets) (f : {hom[Sets] a -> b}).
 
-Definition hom_FreeMonoid (m : {freemon a}) : {freemon b} :=
+Definition FreeMonoid_mor (m : {freemon a}) : {freemon b} :=
   [seq f i | i <- m].
 
-Lemma hom_FreeMonoid1 x : hom_FreeMonoid [fmon x] = [fmon f x].
+Lemma FreeMonoid_mor1 x : FreeMonoid_mor [fmon x] = [fmon f x].
 Proof. by []. Qed.
-Lemma hom_FreeMonoidE (s : {freemon a}) :
-  hom_FreeMonoid s = \prod_(i <- s) [fmon f i].
-Proof. by rewrite /hom_FreeMonoid -[LHS]freemonE big_map. Qed.
-Lemma hom_FreeMonoid_monmorphism : monmorphism hom_FreeMonoid.
-Proof. by rewrite /hom_FreeMonoid; split => [// | /= x y]; rewrite map_cat. Qed.
+Lemma FreeMonoid_morE (s : {freemon a}) :
+  FreeMonoid_mor s = \prod_(i <- s) [fmon f i].
+Proof. by rewrite /FreeMonoid_mor -[LHS]freemonE big_map. Qed.
+Lemma FreeMonoid_mor_monmorphism : monmorphism FreeMonoid_mor.
+Proof. by rewrite /FreeMonoid_mor; split => [// | /= x y]; rewrite map_cat. Qed.
 
 End FreeMonoid.
 
 HB.instance Definition _ (a b : Sets) (f : {hom[Sets] a -> b}) :=
   @isHom.Build Monoids {freemon a} {freemon b}
-    (hom_FreeMonoid f : [the Monoids of {freemon a}] -> {freemon b})
-    (hom_FreeMonoid_monmorphism f).
-Definition FreeMonoid_mor (a b : Sets) (f : {hom[Sets] a -> b})
-  : {hom[Monoids] {freemon a} -> {freemon b}} := hom_FreeMonoid f.
+    (FreeMonoid_mor f : [the Monoids of {freemon a}] -> {freemon b})
+    (FreeMonoid_mor_monmorphism f).
 
 Fact FreeMonoid_ext : FunctorLaws.ext FreeMonoid_mor.
-Proof. by move=> /= a b f g eq y; rewrite /hom_FreeMonoid; exact: eq_map. Qed.
+Proof. by move=> /= a b f g eq y; rewrite /FreeMonoid_mor; exact: eq_map. Qed.
 Fact FreeMonoid_id : FunctorLaws.id FreeMonoid_mor.
-Proof. by move=> /= a x /=; rewrite /hom_FreeMonoid /= map_id. Qed.
+Proof. by move=> /= a x /=; rewrite /FreeMonoid_mor /= map_id. Qed.
 Fact FreeMonoid_comp  : FunctorLaws.comp FreeMonoid_mor.
-Proof. by move=> /= a b c f g x; rewrite /= /hom_FreeMonoid -map_comp. Qed.
-Definition FreeMonoid T : Monoids := {freemon T}.
+Proof. by move=> /= a b c f g x; rewrite /= /FreeMonoid_mor -map_comp. Qed.
+Definition FreeMonoid_functor T : Monoids := {freemon T}.
 HB.instance Definition _ :=
-  @isFunctor.Build Sets Monoids
-    FreeMonoid FreeMonoid_mor FreeMonoid_ext FreeMonoid_id FreeMonoid_comp.
+  @isFunctor.Build Sets Monoids FreeMonoid_functor
+    FreeMonoid_mor FreeMonoid_ext FreeMonoid_id FreeMonoid_comp.
+Definition FreeMonoid : {functor Sets -> Monoids} :=  FreeMonoid_functor.
 
 
 Module FreeMonoidAdjoint.
@@ -937,7 +948,7 @@ Fact eps_natural : naturality (FreeMonoid \O forget_Monoids_to_Sets) FId eps.
 Proof.
 move=> /= a b h x /=.
 rewrite -!mmorphism_of_MonoidsE [LHS]mmorph_prod /=.
-by rewrite FIdf /eps_fun /= /hom_FreeMonoid big_map.
+by rewrite FIdf /eps_fun /= /FreeMonoid_mor big_map.
 Qed.
 HB.instance Definition _ :=
   @isNatural.Build Monoids Monoids
@@ -946,7 +957,7 @@ HB.instance Definition _ :=
 Fact triL : TriangularLaws.left eta eps.
 Proof.
 move=> /= a x.
-rewrite -!mmorphism_of_MonoidsE /= /eps_fun /hom_FreeMonoid.
+rewrite -!mmorphism_of_MonoidsE /= /eps_fun /FreeMonoid_mor.
 by rewrite big_map -[RHS]freemonE.
 Qed.
 Fact triR : TriangularLaws.right eta eps.
@@ -1021,184 +1032,190 @@ Proof. by []. Qed.
 
 
 (** Equivalence ComMonoid NModule ***********************************)
-
-Record NMod_of_ComMonoidT (M : ComMonoids) :=
-  NModOfCommonoid { nmod_of_commonoid_val : M }.
-Definition nmod_of_commonoid M x := @NModOfCommonoid M x.
-Definition nmod_of_commonoid_inv M x := @nmod_of_commonoid_val M x.
-Lemma nmod_of_commonoidK M :
-  cancel (@nmod_of_commonoid M) (@nmod_of_commonoid_inv M).
+Record NModule_of_ComMonoidT (M : ComMonoids) :=
+  NModOfCMon { nmod_of_cmon_val : M }.
+Definition nmod_of_cmon M x := @NModOfCMon M x.
+Definition nmod_of_cmon_inv M x := @nmod_of_cmon_val M x.
+Lemma nmod_of_cmonK M :
+  cancel (@nmod_of_cmon M) (@nmod_of_cmon_inv M).
 Proof. by []. Qed.
-Lemma nmod_of_commonoid_invK M :
-  cancel (@nmod_of_commonoid_inv M) (@nmod_of_commonoid M).
+Lemma nmod_of_cmon_invK M :
+  cancel (@nmod_of_cmon_inv M) (@nmod_of_cmon M).
 Proof. by case. Qed.
 
 Section Defs.
 
 Variable M : ComMonoids.
-Local Notation nmodM := (NMod_of_ComMonoidT M).
+Local Notation nmodM := (NModule_of_ComMonoidT M).
 HB.instance Definition _ :=
-  Choice.copy nmodM (can_type (@nmod_of_commonoid_invK M)).
+  Choice.copy nmodM (can_type (@nmod_of_cmon_invK M)).
 
-Let zeronm := @nmod_of_commonoid M 1%M.
+Let zeronm := @nmod_of_cmon M 1%M.
 Let addnm (x y : nmodM) :=
-  nmod_of_commonoid (nmod_of_commonoid_inv x * nmod_of_commonoid_inv y).
+  nmod_of_cmon (nmod_of_cmon_inv x * nmod_of_cmon_inv y).
 Fact addnmA : associative addnm.
-Proof. by move=> x y z; rewrite /addnm !nmod_of_commonoidK mulmA. Qed.
+Proof. by move=> x y z; rewrite /addnm !nmod_of_cmonK mulmA. Qed.
 Fact addnmC : commutative addnm.
 Proof. by move=> x y; rewrite /addnm mulmC. Qed.
 Fact add0nm : left_id zeronm addnm.
 Proof.
 move=> x.
-by rewrite /addnm /zeronm nmod_of_commonoidK mul1m nmod_of_commonoid_invK.
+by rewrite /addnm /zeronm nmod_of_cmonK mul1m nmod_of_cmon_invK.
 Qed.
 HB.instance Definition _ := GRing.isNmodule.Build nmodM addnmA addnmC add0nm.
-Definition NMod_of_ComMonoid : NModules := nmodM.
+Definition NMod_of_CMon_obj : NModules := nmodM.
 
-Lemma nmod_of_commonoid1 : nmod_of_commonoid 1 = 0%R:> nmodM.
+Lemma nmod_of_cmon1 : nmod_of_cmon 1 = 0%R:> nmodM.
 Proof. by []. Qed.
-Lemma nmod_of_commonoidM :
-  {morph @nmod_of_commonoid M : x y / (x * y)%M >-> (x + y)%R}.
-Proof. by move=> x y; rewrite /GRing.add /= /addnm !nmod_of_commonoidK. Qed.
-Definition nmod_of_commonoid_prod :=
-  big_morph _ nmod_of_commonoidM nmod_of_commonoid1.
+Lemma nmod_of_cmonM :
+  {morph @nmod_of_cmon M : x y / (x * y)%M >-> (x + y)%R}.
+Proof. by move=> x y; rewrite /GRing.add /= /addnm !nmod_of_cmonK. Qed.
+Definition nmod_of_cmon_prod :=
+  big_morph _ nmod_of_cmonM nmod_of_cmon1.
 
 End Defs.
 
 Section Functor_on_Hom.
 
 Variables (M N : ComMonoids) (f : {hom[ComMonoids] M -> N}).
-Let nmod_of_commonoid_mor : (NMod_of_ComMonoid M) -> (NMod_of_ComMonoid N) :=
-  (@nmod_of_commonoid N) \o f \o (@nmod_of_commonoid_inv M).
+Let nmod_of_cmon_mor : (NMod_of_CMon_obj M) -> (NMod_of_CMon_obj N) :=
+  (@nmod_of_cmon N) \o f \o (@nmod_of_cmon_inv M).
 
-Fact nmod_of_commonoid_mor_nmod_morphism : nmod_morphism nmod_of_commonoid_mor.
+Fact nmod_of_cmon_mor_nmod_morphism : nmod_morphism nmod_of_cmon_mor.
 Proof.
-rewrite /nmod_of_commonoid_mor; split => /= [|x y /=].
-  by rewrite -nmod_of_commonoid1 -(mmorphism_of_ComMonoidsE f) mmorph1.
-by rewrite -nmod_of_commonoidM -(mmorphism_of_ComMonoidsE f) -mmorphM.
+rewrite /nmod_of_cmon_mor; split => /= [|x y /=].
+  by rewrite -nmod_of_cmon1 -(mmorphism_of_ComMonoidsE f) mmorph1.
+by rewrite -nmod_of_cmonM -(mmorphism_of_ComMonoidsE f) -mmorphM.
 Qed.
 HB.instance Definition _ :=
-  isHom.Build NModules (NMod_of_ComMonoid M) (NMod_of_ComMonoid N)
-    nmod_of_commonoid_mor nmod_of_commonoid_mor_nmod_morphism.
-Definition NMod_of_ComMonoid_mor
-  : {hom[NModules] NMod_of_ComMonoid M -> NMod_of_ComMonoid N}
-  := nmod_of_commonoid_mor.
+  isHom.Build NModules (NMod_of_CMon_obj M) (NMod_of_CMon_obj N)
+    nmod_of_cmon_mor nmod_of_cmon_mor_nmod_morphism.
+Definition NMod_of_CMon_mor
+  : {hom[NModules] NMod_of_CMon_obj M -> NMod_of_CMon_obj N}
+  := nmod_of_cmon_mor.
 
 End Functor_on_Hom.
 
-Fact NMod_of_ComMonoid_ext : FunctorLaws.ext NMod_of_ComMonoid_mor.
+Fact NMod_of_CMon_ext : FunctorLaws.ext NMod_of_CMon_mor.
 Proof. by move=> /= a b f g eq y; rewrite /= eq. Qed.
-Fact NMod_of_ComMonoid_id : FunctorLaws.id NMod_of_ComMonoid_mor.
-Proof. by move=> /= a x /=; rewrite /= nmod_of_commonoid_invK. Qed.
-Fact NMod_of_ComMonoid_comp  : FunctorLaws.comp NMod_of_ComMonoid_mor.
+Fact NMod_of_CMon_id : FunctorLaws.id NMod_of_CMon_mor.
+Proof. by move=> /= a x /=; rewrite /= nmod_of_cmon_invK. Qed.
+Fact NMod_of_CMon_comp  : FunctorLaws.comp NMod_of_CMon_mor.
 Proof. by []. Qed.
 HB.instance Definition _ :=
-  @isFunctor.Build ComMonoids NModules NMod_of_ComMonoid NMod_of_ComMonoid_mor
-    NMod_of_ComMonoid_ext NMod_of_ComMonoid_id NMod_of_ComMonoid_comp.
+  @isFunctor.Build ComMonoids NModules NMod_of_CMon_obj NMod_of_CMon_mor
+    NMod_of_CMon_ext NMod_of_CMon_id NMod_of_CMon_comp.
 
+Definition NModule_of_ComMonoid : {functor ComMonoids -> NModules}
+  := NMod_of_CMon_obj.
 
-Record ComMonoid_of_NModT (M : NModules) :=
-  CommonoidOfNMod { commonoid_of_nmod_val : M }.
-Definition commonoid_of_nmod M x := @CommonoidOfNMod M x.
-Definition commonoid_of_nmod_inv M x := @commonoid_of_nmod_val M x.
-Lemma commonoid_of_nmodK M :
-  cancel (@commonoid_of_nmod M) (@commonoid_of_nmod_inv M).
+Record ComMonoid_of_NModuleT (M : NModules) :=
+  CMonOfNMod { cmon_of_nmod_val : M }.
+Definition cmon_of_nmod M x := @CMonOfNMod M x.
+Definition cmon_of_nmod_inv M x := @cmon_of_nmod_val M x.
+Lemma cmon_of_nmodK M :
+  cancel (@cmon_of_nmod M) (@cmon_of_nmod_inv M).
 Proof. by []. Qed.
-Lemma commonoid_of_nmod_invK M :
-  cancel (@commonoid_of_nmod_inv M) (@commonoid_of_nmod M).
+Lemma cmon_of_nmod_invK M :
+  cancel (@cmon_of_nmod_inv M) (@cmon_of_nmod M).
 Proof. by case. Qed.
 
 
 Section Defs.
 
 Variable M : NModules.
-Local Notation cmonM := (ComMonoid_of_NModT M).
+Local Notation cmonM := (ComMonoid_of_NModuleT M).
 HB.instance Definition _ :=
-  Choice.copy cmonM (can_type (@commonoid_of_nmod_invK M)).
+  Choice.copy cmonM (can_type (@cmon_of_nmod_invK M)).
 
-Let onecm := @commonoid_of_nmod M 0%R.
+Let onecm := @cmon_of_nmod M 0%R.
 Let mulcm (x y : cmonM) :=
-  commonoid_of_nmod (commonoid_of_nmod_inv x + commonoid_of_nmod_inv y).
+  cmon_of_nmod (cmon_of_nmod_inv x + cmon_of_nmod_inv y).
 Fact mulcmA : associative mulcm.
-Proof. by move=> x y z; rewrite /mulcm !commonoid_of_nmodK addrA. Qed.
+Proof. by move=> x y z; rewrite /mulcm !cmon_of_nmodK addrA. Qed.
 Fact mulcmC : commutative mulcm.
 Proof. by move=> x y; rewrite /mulcm addrC. Qed.
 Fact mul1cm : left_id onecm mulcm.
 Proof.
 move=> x.
-by rewrite /mulcm /onecm commonoid_of_nmodK add0r commonoid_of_nmod_invK.
+by rewrite /mulcm /onecm cmon_of_nmodK add0r cmon_of_nmod_invK.
 Qed.
 HB.instance Definition _ := isComMonoid.Build cmonM mulcmA mulcmC mul1cm.
-Definition ComMonoid_of_NMod : ComMonoids := cmonM.
+Definition CMon_of_NMod_obj : ComMonoids := cmonM.
 
-Lemma commonoid_of_nmod0 : commonoid_of_nmod 0%R = 1%M:> cmonM.
+Lemma cmon_of_nmod0 : cmon_of_nmod 0%R = 1%M:> cmonM.
 Proof. by []. Qed.
-Lemma commonoid_of_nmodD :
-  {morph @commonoid_of_nmod M : x y / (x + y)%R >-> (x * y)%M}.
-Proof. by move=> x y; rewrite /mul /= /mulcm !commonoid_of_nmodK. Qed.
-Definition commonoid_of_nmod_sum :=
-  big_morph _ commonoid_of_nmodD commonoid_of_nmod0.
+Lemma cmon_of_nmodD :
+  {morph @cmon_of_nmod M : x y / (x + y)%R >-> (x * y)%M}.
+Proof. by move=> x y; rewrite /mul /= /mulcm !cmon_of_nmodK. Qed.
+Definition cmon_of_nmod_sum :=
+  big_morph _ cmon_of_nmodD cmon_of_nmod0.
 
 End Defs.
 
 Section Functor_on_Hom.
 
 Variables (M N : NModules) (f : {hom[NModules] M -> N}).
-Let commonoid_of_nmod_mor : (ComMonoid_of_NMod M) -> (ComMonoid_of_NMod N) :=
-  (@commonoid_of_nmod N) \o f \o (@commonoid_of_nmod_inv M).
+Let cmon_of_nmod_mor : (CMon_of_NMod_obj M) -> (CMon_of_NMod_obj N) :=
+  (@cmon_of_nmod N) \o f \o (@cmon_of_nmod_inv M).
 
-Fact commonoid_of_nmod_mor_monmorphism : monmorphism commonoid_of_nmod_mor.
+Fact cmon_of_nmod_mor_monmorphism : monmorphism cmon_of_nmod_mor.
 Proof.
-rewrite /commonoid_of_nmod_mor; split => /= [|x y].
-  by rewrite -commonoid_of_nmod0 -(additive_of_NmodE f) raddf0.
-by rewrite -commonoid_of_nmodD -(additive_of_NmodE f) -raddfD.
+rewrite /cmon_of_nmod_mor; split => /= [|x y].
+  by rewrite -cmon_of_nmod0 -(additive_of_NmodE f) raddf0.
+by rewrite -cmon_of_nmodD -(additive_of_NmodE f) -raddfD.
 Qed.
 HB.instance Definition _ :=
-  isHom.Build ComMonoids (ComMonoid_of_NMod M) (ComMonoid_of_NMod N)
-    commonoid_of_nmod_mor commonoid_of_nmod_mor_monmorphism.
-Definition ComMonoid_of_NMod_mor
-  : {hom[ComMonoids] ComMonoid_of_NMod M -> ComMonoid_of_NMod N}
-  := commonoid_of_nmod_mor.
+  isHom.Build ComMonoids (CMon_of_NMod_obj M) (CMon_of_NMod_obj N)
+    cmon_of_nmod_mor cmon_of_nmod_mor_monmorphism.
+Definition CMon_of_NMod_mor
+  : {hom[ComMonoids] CMon_of_NMod_obj M -> CMon_of_NMod_obj N}
+  := cmon_of_nmod_mor.
 
 End Functor_on_Hom.
 
-Fact ComMonoid_of_NMod_ext : FunctorLaws.ext ComMonoid_of_NMod_mor.
+Fact CMon_of_NMod_ext : FunctorLaws.ext CMon_of_NMod_mor.
 Proof. by move=> /= a b f g eq y; rewrite /= eq. Qed.
-Fact ComMonoid_of_NMod_id : FunctorLaws.id ComMonoid_of_NMod_mor.
-Proof. by move=> /= a x /=; rewrite /= commonoid_of_nmod_invK. Qed.
-Fact ComMonoid_of_NMod_comp  : FunctorLaws.comp ComMonoid_of_NMod_mor.
+Fact CMon_of_NMod_id : FunctorLaws.id CMon_of_NMod_mor.
+Proof. by move=> /= a x /=; rewrite /= cmon_of_nmod_invK. Qed.
+Fact CMon_of_NMod_comp  : FunctorLaws.comp CMon_of_NMod_mor.
 Proof. by []. Qed.
 HB.instance Definition _ :=
-  @isFunctor.Build NModules ComMonoids ComMonoid_of_NMod ComMonoid_of_NMod_mor
-    ComMonoid_of_NMod_ext ComMonoid_of_NMod_id ComMonoid_of_NMod_comp.
+  @isFunctor.Build NModules ComMonoids CMon_of_NMod_obj CMon_of_NMod_mor
+    CMon_of_NMod_ext CMon_of_NMod_id CMon_of_NMod_comp.
 
-(** Doesn't seems to be provable, equality is too strong.
-Lemma CM_id : ComMonoid_of_NMod \O NMod_of_ComMonoid =#= FId.
+Definition ComMonoid_of_NModule : {functor NModules -> ComMonoids} :=
+  CMon_of_NMod_obj.
+
+  (** Doesn't seems to be provable, equality is too strong.
+Lemma CM_id : CMon_of_NMod \O NMod_of_CMon =#= FId.
  *)
 
-Local Notation CM := (ComMonoid_of_NMod \O NMod_of_ComMonoid).
-Local Notation MC := (NMod_of_ComMonoid \O ComMonoid_of_NMod).
+Module EquivCatComMonoidNModule.
+
+Local Notation CM := (ComMonoid_of_NModule \O NModule_of_ComMonoid).
+Local Notation MC := (NModule_of_ComMonoid \O ComMonoid_of_NModule).
 
 (** Build natural isom *)
 Section IsoCM.
 
 Variable M : ComMonoids.
 Definition isoCM_map : CM M -> FId M :=
-  (@nmod_of_commonoid_inv _) \o (@commonoid_of_nmod_inv (NMod_of_ComMonoid M)).
+  (@nmod_of_cmon_inv _) \o (@cmon_of_nmod_inv (NModule_of_ComMonoid M)).
 Definition isoCM_inv : FId M -> CM M :=
-  (@commonoid_of_nmod _) \o (@nmod_of_commonoid M).
+  (@cmon_of_nmod _) \o (@nmod_of_cmon M).
 
 Fact isoCM_mapK : cancel isoCM_map isoCM_inv.
 Proof.
 rewrite /isoCM_map {}/isoCM_inv => x /=.
-by rewrite !(nmod_of_commonoid_invK, commonoid_of_nmod_invK).
+by rewrite !(nmod_of_cmon_invK, cmon_of_nmod_invK).
 Qed.
 Fact isoCM_invK : cancel isoCM_inv isoCM_map.
 Proof. by []. Qed.
 Fact isoCM_monmorphism : monmorphism isoCM_map.
 Proof.
 split => [|x y].
-  by rewrite -commonoid_of_nmod0 -nmod_of_commonoid1.
+  by rewrite -cmon_of_nmod0 -nmod_of_cmon1.
 by rewrite -{1}(isoCM_mapK x) -{1}(isoCM_mapK y).
 Qed.
 HB.instance Definition _ :=
@@ -1207,8 +1224,8 @@ HB.instance Definition _ :=
 Fact isoCM_inv_monmorphism : monmorphism isoCM_inv.
 Proof.
 rewrite /isoCM_inv; split => [|x y ] /=.
-  by rewrite -commonoid_of_nmod0 nmod_of_commonoid1.
-by rewrite nmod_of_commonoidM commonoid_of_nmodD.
+  by rewrite -cmon_of_nmod0 nmod_of_cmon1.
+by rewrite nmod_of_cmonM cmon_of_nmodD.
 Qed.
 HB.instance Definition _ :=
   isIsom.Build ComMonoids (CM M) M isoCM_map
@@ -1236,21 +1253,21 @@ Section IsoMC.
 
 Variable M : NModules.
 Definition isoMC_map : MC M -> FId M :=
-  (@commonoid_of_nmod_inv _) \@ (@nmod_of_commonoid_inv (ComMonoid_of_NMod M)).
+  (@cmon_of_nmod_inv _) \@ (@nmod_of_cmon_inv (ComMonoid_of_NModule M)).
 Definition isoMC_inv : FId M -> MC M :=
-  (@nmod_of_commonoid _) \@ (@commonoid_of_nmod M).
+  (@nmod_of_cmon _) \@ (@cmon_of_nmod M).
 
 Fact isoMC_mapK : cancel isoMC_map isoMC_inv.
 Proof.
 rewrite /isoMC_map {}/isoMC_inv => x /=.
-by rewrite !(nmod_of_commonoid_invK, commonoid_of_nmod_invK).
+by rewrite !(nmod_of_cmon_invK, cmon_of_nmod_invK).
 Qed.
 Fact isoMC_invK : cancel isoMC_inv isoMC_map.
 Proof. by []. Qed.
 Fact isoMC_nmod_morphism : nmod_morphism isoMC_map.
 Proof.
 split => [| x y].
-  by rewrite -nmod_of_commonoid1 -commonoid_of_nmod0.
+  by rewrite -nmod_of_cmon1 -cmon_of_nmod0.
 by rewrite -{1}(isoMC_mapK x) -{1}(isoMC_mapK y).
 Qed.
 HB.instance Definition _ :=
@@ -1259,8 +1276,8 @@ HB.instance Definition _ :=
 Fact isoMC_inv_nmod_morphism : nmod_morphism isoMC_inv.
 Proof.
 rewrite /isoMC_inv; split => [| x y] /=.
-  by rewrite -nmod_of_commonoid1 commonoid_of_nmod0.
-by rewrite commonoid_of_nmodD nmod_of_commonoidM.
+  by rewrite -nmod_of_cmon1 cmon_of_nmod0.
+by rewrite cmon_of_nmodD nmod_of_cmonM.
 Qed.
 HB.instance Definition _ :=
   isIsom.Build NModules (MC M) M isoMC_map
@@ -1284,54 +1301,56 @@ Definition isoMC : MC ~> FId := isoMC_hom.
 End IsoMCTrans.
 
 Definition equivalence_ComMonoids_NModules :
-  equivalence_category NMod_of_ComMonoid ComMonoid_of_NMod :=
+  equivalence_category NModule_of_ComMonoid ComMonoid_of_NModule :=
   EquivalenceCategory natural_isoMC natural_isoCM.
 
 
-Module ComMonoids_NModules_Adjoints.
 Section Defs.
 
-Let epsMC : NMod_of_ComMonoid \O ComMonoid_of_NMod ~> FId
+Let epsMC : NModule_of_ComMonoid \O ComMonoid_of_NModule ~> FId
     := eqFGId_trans equivalence_ComMonoids_NModules.
-Let etaMC : FId ~> ComMonoid_of_NMod \O NMod_of_ComMonoid
+Let etaMC : FId ~> ComMonoid_of_NModule \O NModule_of_ComMonoid
     := eqIdGF_trans equivalence_ComMonoids_NModules.
 
 Fact triRMC : TriangularLaws.right etaMC epsMC.
 Proof.
 move=> /= a x /=.
-by rewrite /isoMC_map /= commonoid_of_nmod_invK.
+by rewrite /isoMC_map /= cmon_of_nmod_invK.
 Qed.
 Fact triLMC : TriangularLaws.left etaMC epsMC.
-Proof. by move=> a x /=; rewrite /isoMC_map /= nmod_of_commonoid_invK. Qed.
+Proof. by move=> a x /=; rewrite /isoMC_map /= nmod_of_cmon_invK. Qed.
 
-Definition compMC : NMod_of_ComMonoid -| ComMonoid_of_NMod
+Definition compMC : NModule_of_ComMonoid -| ComMonoid_of_NModule
   := AdjointFunctors.mk triLMC triRMC.
 
 
-Let epsCM : ComMonoid_of_NMod \O NMod_of_ComMonoid~> FId
+Let epsCM : ComMonoid_of_NModule \O NModule_of_ComMonoid~> FId
     := eqGFId_trans equivalence_ComMonoids_NModules.
-Let etaCM : FId ~> NMod_of_ComMonoid \O ComMonoid_of_NMod
+Let etaCM : FId ~> NModule_of_ComMonoid \O ComMonoid_of_NModule
     := eqIdFG_trans equivalence_ComMonoids_NModules.
 
 Fact triRCM : TriangularLaws.right etaCM epsCM.
 Proof.
 move=> /= a x /=.
-by rewrite /isoCM_map /= nmod_of_commonoid_invK.
+by rewrite /isoCM_map /= nmod_of_cmon_invK.
 Qed.
 Fact triLCM : TriangularLaws.left etaCM epsCM.
 Proof.
 move=> /= a x /=.
-by rewrite /isoCM_map /= commonoid_of_nmod_invK.
+by rewrite /isoCM_map /= cmon_of_nmod_invK.
 Qed.
 
-Definition compCM : ComMonoid_of_NMod -| NMod_of_ComMonoid
+Definition compCM : ComMonoid_of_NModule -| NModule_of_ComMonoid
   := AdjointFunctors.mk triLCM triRCM.
 
 End Defs.
-End ComMonoids_NModules_Adjoints.
 
-Notation adjoint_ComMonoid_NModule := ComMonoids_NModules_Adjoints.compCM.
-Notation adjoint_NModule_ComMonoid := ComMonoids_NModules_Adjoints.compMC.
+End EquivCatComMonoidNModule.
+
+Notation equivalence_ComMonoids_NModules :=
+  EquivCatComMonoidNModule.equivalence_ComMonoids_NModules.
+Notation adjoint_ComMonoid_NModule := EquivCatComMonoidNModule.compCM.
+Notation adjoint_NModule_ComMonoid := EquivCatComMonoidNModule.compMC.
 
 
 (* TODO: Those are full subcategories, devise some infrastructure to
@@ -1364,19 +1383,23 @@ Local Open Scope ring_scope.
 Local Open Scope mset_scope.
 
 (** Adjunction between forget : NModules -> Sets and free N-Modules *)
-Section Set_to_FreeNmodule.
+Definition FreeNModule_obj (E : Sets) : NModules := {mset E}.
+Notation "{ 'freenmod' E }" := (FreeNModule_obj E)
+                                (at level 0, format "{ 'freenmod'  E }").
 
-Variable (a b : Sets) (f : {hom[Sets] a -> b}).
+Section Morphisms.
 
-Definition hom_mset (m : {mset a}) : {mset b} :=
-  \sum_(i <- m) [mset f i].
+Variable (A B : Sets) (f : {hom[Sets] A -> B}).
 
-Lemma hom_mset1 x : hom_mset [mset x] = [mset f x].
-Proof. by rewrite /hom_mset big_msetn /=. Qed.
+Definition FreeNModule_mor (m : {freenmod A}) : {freenmod B} :=
+  \sum_(i <- (m : {mset A})) [mset f i].
 
-Lemma hom_mset_is_nmod_morphism : nmod_morphism hom_mset.
+Lemma FreeNModule_mor1 x : FreeNModule_mor [mset x] = [mset f x].
+Proof. by rewrite /FreeNModule_mor big_msetn /=. Qed.
+
+Lemma FreeNModule_mor_is_nmod_morphism : nmod_morphism FreeNModule_mor.
 Proof.
-rewrite /hom_mset; split => [| /= x y]; first by rewrite big_mset0.
+rewrite /FreeNModule_mor; split => [| /= x y]; first by rewrite big_mset0.
 apply msetP => u /=; rewrite msetDE !mset_sum !sum_mset.
 under eq_bigr => i _ do rewrite msetDE natrDE mulnDl.
 rewrite natrDE big_split /=; congr (_ + _)%N.
@@ -1386,46 +1409,41 @@ rewrite addrC; apply: finsupp_widenD => i.
 by rewrite msuppE -mset_eq0 => /eqP -> /[!mul0n].
 Qed.
 
-End Set_to_FreeNmodule.
+End Morphisms.
 
-Definition FreeNModule (T : Sets) : NModules := {mset T}.
-(* TODO Cyril : The following declaration was
+(* TODO Ask experts : The following declaration was
 
 Definition FreeNModule (T : choiceType) : nmodType := {mset T}.
   HB.instance Definition _ (a b : Sets) (f : a -> b) :=
    @isHom.Build NModules {mset a} {mset b}
-   (hom_mset f : [the nmodType of {mset a}] -> [the nmodType of {mset b}])
-   (hom_mset_additive f).
+   (FreeNModule_mor f : [the nmodType of {mset a}] -> [the nmodType of {mset b}])
+   (FreeNModule_mor_additive f).
 
 the [the nmodType of ... ] was needed... Why ???
 *)
 HB.instance Definition _ (a b : Sets) (f : {hom[Sets] a -> b}) :=
-  @isHom.Build NModules (FreeNModule a) (FreeNModule b)
-    (hom_mset f : FreeNModule a -> FreeNModule b)
-    (hom_mset_is_nmod_morphism f).
-Definition FreeNModule_mor (a b : Sets) (f : {hom[Sets] a -> b})
-  : {hom[NModules] FreeNModule a -> FreeNModule b} := hom_mset f.
+  @isHom.Build NModules (FreeNModule_obj a) (FreeNModule_obj b)
+    (FreeNModule_mor f : FreeNModule_obj a -> FreeNModule_obj b)
+    (FreeNModule_mor_is_nmod_morphism f).
 
 Fact FreeNModule_ext : FunctorLaws.ext FreeNModule_mor.
 Proof.
-move=> /= a b f g eq y; rewrite /hom_mset.
+move=> /= a b f g eq y; rewrite /FreeNModule_mor.
 by apply eq_bigr => x _; rewrite eq.
 Qed.
 Fact FreeNModule_id : FunctorLaws.id FreeNModule_mor.
-Proof. by move=> /= a x /=; rewrite /hom_mset /= msetE. Qed.
+Proof. by move=> /= a x /=; rewrite /FreeNModule_mor /= msetE. Qed.
 Fact FreeNModule_comp  : FunctorLaws.comp FreeNModule_mor.
 Proof.
 move=> /= a b c f g.
 rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!additive_of_NmodE; apply: additive_msetE => /= x.
-by rewrite /hom_mset /= !big_msetn.
+by rewrite /FreeNModule_mor /= !big_msetn.
 Qed.
 HB.instance Definition _ :=
-  @isFunctor.Build Sets NModules
-    FreeNModule FreeNModule_mor FreeNModule_ext FreeNModule_id FreeNModule_comp.
-
-Notation "{ 'freenmod' T }" := (FreeNModule T)
-                                (at level 0, format "{ 'freenmod'  T }").
+  @isFunctor.Build Sets NModules FreeNModule_obj FreeNModule_mor
+    FreeNModule_ext FreeNModule_id FreeNModule_comp.
+Definition FreeNModule : {functor Sets -> NModules} := FreeNModule_obj.
 
 Module FreeNModuleAdjoint.
 Section Adjoint.
@@ -1436,7 +1454,7 @@ Definition eta_fun a (x : a) := [mset x].
 Definition eta : FId ~~> forget_NModules_to_Sets \O FreeNModule := eta_fun.
 Fact eta_natural :
   naturality FId (forget_NModules_to_Sets \O FreeNModule) eta.
-Proof. by move=> /= a b h x /=; rewrite /eta_fun FIdf hom_mset1. Qed.
+Proof. by move=> /= a b h x /=; rewrite /eta_fun FIdf FreeNModule_mor1. Qed.
 HB.instance Definition _ :=
   @isNatural.Build Sets Sets FId
     (forget_NModules_to_Sets \O FreeNModule) eta eta_natural.
@@ -1458,7 +1476,7 @@ Proof.
 move=> /= a b h.
 rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!additive_of_NmodE; apply: additive_msetE => /= x.
-by rewrite FIdf /eps_fun /hom_mset /= !big_msetn.
+by rewrite FIdf /eps_fun /FreeNModule_mor /= !big_msetn.
 Qed.
 HB.instance Definition _ :=
   @isNatural.Build NModules NModules
@@ -1469,7 +1487,7 @@ Proof.
 move=> /= a.
 rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!additive_of_NmodE; apply: additive_msetE => /= x.
-by rewrite /eta_fun /= /eps_fun /hom_mset /= !big_msetn.
+by rewrite /eta_fun /= /eps_fun /FreeNModule_mor /= !big_msetn.
 Qed.
 Fact triR : TriangularLaws.right eta eps.
 Proof. by move=> /= M m; rewrite /eta_fun /= /eps_fun !big_msetn /=. Qed.
@@ -1505,14 +1523,14 @@ End UniversalProperty.
 
 
 
-Definition FreeComMonoid := ComMonoid_of_NMod \O FreeNModule.
+Definition FreeComMonoid := ComMonoid_of_NModule \O FreeNModule.
 Notation "{ 'freecmon' T }" := (FreeComMonoid T)
   (at level 0, format "{ 'freecmon'  T }").
 
-Definition cmon_gen A a : {freecmon A} := commonoid_of_nmod [mset a].
+Definition cmon_gen A a : {freecmon A} := cmon_of_nmod [mset a].
 #[warning="-uniform-inheritance"]
 Coercion enum_freecmon A (m : {freecmon A}) : seq A :=
-                            (commonoid_of_nmod_inv m : {mset A}).
+                            (cmon_of_nmod_inv m : {mset A}).
 
 Section FreeComMonoidTheory.
 Variable (A : Sets).
@@ -1520,34 +1538,34 @@ Implicit Types (m n : {freecmon A}).
 
 Lemma freecmon1E m : (1%M : {freecmon A}) = [::] :> seq A.
 Proof.
-by rewrite /enum_freecmon -commonoid_of_nmod0 commonoid_of_nmodK enum_mset0.
+by rewrite /enum_freecmon -cmon_of_nmod0 cmon_of_nmodK enum_mset0.
 Qed.
 Lemma freecmonE m : (\prod_(i <- m) cmon_gen i)%M = m.
 Proof.
-have:= congr1 (@commonoid_of_nmod _) (msetE (commonoid_of_nmod_inv m)).
-by rewrite commonoid_of_nmod_invK commonoid_of_nmod_sum => {2}<-.
+have:= congr1 (@cmon_of_nmod _) (msetE (cmon_of_nmod_inv m)).
+by rewrite cmon_of_nmod_invK cmon_of_nmod_sum => {2}<-.
 Qed.
 
 End FreeComMonoidTheory.
 
-Local Notation nmodSet := (forget_NModules_to_Sets \O NMod_of_ComMonoid).
+#[local] Notation nmodSet := (forget_NModules_to_Sets \O NModule_of_ComMonoid).
 
 Module FreeComMonoidAdjoint.
 Section FixForgetNmodSet.
 Variable (M : ComMonoids).
 
 Definition transf_to_nmodset_fun :
-  forget_ComMonoids_to_Sets M -> nmodSet M := fun (r : M) => nmod_of_commonoid r.
+  forget_ComMonoids_to_Sets M -> nmodSet M := fun (r : M) => nmod_of_cmon r.
 Definition transf_from_nmodset_fun :
   nmodSet M -> forget_ComMonoids_to_Sets M :=
-  fun (r : nmodSet M) => nmod_of_commonoid_inv r.
+  fun (r : nmodSet M) => nmod_of_cmon_inv r.
 
 Lemma transf_to_nmodset_funK :
   cancel transf_to_nmodset_fun transf_from_nmodset_fun.
-Proof. exact: nmod_of_commonoidK. Qed.
+Proof. exact: nmod_of_cmonK. Qed.
 Lemma transf_from_nmodset_funK :
   cancel transf_from_nmodset_fun transf_to_nmodset_fun.
-Proof. exact: nmod_of_commonoid_invK. Qed.
+Proof. exact: nmod_of_cmon_invK. Qed.
 
 HB.instance Definition _ :=
   isHom.Build Sets (forget_ComMonoids_to_Sets M) (nmodSet M)
@@ -1581,10 +1599,10 @@ HB.instance Definition _ :=
 
 Lemma transf_to_nmodsetK M :
   cancel (transf_to_nmodset M) (transf_from_nmodset M).
-Proof. exact: nmod_of_commonoidK. Qed.
+Proof. exact: nmod_of_cmonK. Qed.
 Lemma transf_from_nmodsetK M :
   cancel (transf_from_nmodset M) (transf_to_nmodset M).
-Proof. exact: nmod_of_commonoid_invK. Qed.
+Proof. exact: nmod_of_cmon_invK. Qed.
 
 Definition adjoint :
   FreeComMonoid -| forget_ComMonoids_to_Sets
@@ -1593,6 +1611,7 @@ Definition adjoint :
 
 End FreeComMonoidAdjoint.
 Notation adjoint_FreeComMonoid_forget_to_Sets := FreeComMonoidAdjoint.adjoint.
+
 
 Section UniversalProperty.
 
@@ -1627,10 +1646,10 @@ Local Close Scope monoid_scope.
 Local Open Scope ring_scope.
 
 (** Adjunction free L-Modules -| forget L-Modules to Sets and *)
-Definition FreeLModuleT (R : Rings) (a : Sets) := {freemod R[a]}.
+Definition FreeLModule_obj (R : Rings) (a : Sets) := {freemod R[a]}.
 HB.instance Definition _ (R : Rings) (a : Sets) :=
-  GRing.Lmodule.copy (FreeLModuleT R a) {freemod R[a]}.
-Notation "{ 'freelmod' R [ T ] }" := (FreeLModuleT R T)
+  GRing.Lmodule.copy (FreeLModule_obj R a) {freemod R[a]}.
+Notation "{ 'freelmod' R [ T ] }" := (FreeLModule_obj R T)
   (at level 0, format "{ 'freelmod'  R [ T ] }").
 
 Section Set_to_FreeLmodule.
@@ -1646,14 +1665,14 @@ exact: linear_fmE.
 Qed.
 
 Variable (a b : Sets) (f : {hom[Sets] a -> b}).
-Definition hom_flm (m : {freelmod R[a]}) : {freelmod R[b]} :=
+Definition freelmod_mor (m : {freelmod R[a]}) : {freelmod R[b]} :=
   \sum_(i <- finsupp m) [fm / f i |-> m i].
 
-Lemma hom_flm1 (x : a) : hom_flm [fm / x |-> 1] = [fm / f x |-> 1].
-Proof. by rewrite /hom_flm finsupp_fm1 /= big_seq_fset1 fm1E eqxx. Qed.
-Fact hom_flm_linear : linear hom_flm.
+Lemma freelmod_mor1 (x : a) : freelmod_mor [fm / x |-> 1] = [fm / f x |-> 1].
+Proof. by rewrite /freelmod_mor finsupp_fm1 /= big_seq_fset1 fm1E eqxx. Qed.
+Fact freelmod_mor_linear : linear freelmod_mor.
 Proof.
-rewrite /hom_flm => c /= m n; rewrite scaler_sumr /=.
+rewrite /freelmod_mor => c /= m n; rewrite scaler_sumr /=.
 rewrite -!(finsupp_widen _ (S := finsupp m `|` finsupp n)%fset) /=.
 - rewrite -big_split /=; apply: eq_bigr => x _.
   apply/fsfunP => y; rewrite !fmD !scalefmE !fm1E.
@@ -1669,10 +1688,11 @@ rewrite -!(finsupp_widen _ (S := finsupp m `|` finsupp n)%fset) /=.
 Qed.
 HB.instance Definition _ :=
   GRing.isLinear.Build
-    R {freelmod R[a]} {freelmod R[b]} _ hom_flm hom_flm_linear.
+    R {freelmod R[a]} {freelmod R[b]} _ freelmod_mor freelmod_mor_linear.
 
-Lemma hom_flmc (x : a) (c : R) : hom_flm [fm / x |-> c] = [fm / f x |-> c].
-Proof. by rewrite -fm1ZE linearZ /= hom_flm1 fm1ZE. Qed.
+Lemma freelmod_morc (x : a) (c : R) :
+  freelmod_mor [fm / x |-> c] = [fm / f x |-> c].
+Proof. by rewrite -fm1ZE linearZ /= freelmod_mor1 fm1ZE. Qed.
 
 End Set_to_FreeLmodule.
 
@@ -1682,26 +1702,26 @@ Variable (R : nzRingType).
 
 HB.instance Definition _ (a b : Sets) (f : {hom[Sets] a -> b}) :=
   @isHom.Build (LModules R) {freelmod R[a]} {freelmod R[b]}
-    (hom_flm f : (_ : LModules R) -> _) (hom_flm_linear f).
+    (freelmod_mor f : (_ : LModules R) -> _) (freelmod_mor_linear f).
 Definition FreeLModule_mor (a b : Sets) (f : {hom[Sets] a -> b})
-  : {hom[LModules R] {freelmod R[a]} -> {freelmod R[b]}} := hom_flm f.
+  : {hom[LModules R] {freelmod R[a]} -> {freelmod R[b]}} := freelmod_mor f.
 
 Fact FreeLModule_ext : FunctorLaws.ext FreeLModule_mor.
 Proof.
-move=> /= a b f g eq y; rewrite /hom_mset /hom_flm.
+move=> /= a b f g eq y; rewrite /FreeNModule_mor /freelmod_mor.
 by apply eq_bigr => x _; rewrite eq.
 Qed.
 Fact FreeLModule_id : FunctorLaws.id FreeLModule_mor.
 Proof.
-move=> /= a x /=; rewrite /hom_mset /= -[RHS]fmE.
-by rewrite /hom_flm; apply: eq_bigr => i _.
+move=> /= a x /=; rewrite /FreeNModule_mor /= -[RHS]fmE.
+by rewrite /freelmod_mor; apply: eq_bigr => i _.
 Qed.
 Fact FreeLModule_comp  : FunctorLaws.comp FreeLModule_mor.
 Proof.
 move=> /= a b c f g.
 rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!linear_of_LmodE; apply: linear_fmE => /= x.
-by rewrite /hom_flm /= !(finsupp_fm1, big_seq_fset1, fm1E, eqxx).
+by rewrite /freelmod_mor /= !(finsupp_fm1, big_seq_fset1, fm1E, eqxx).
 Qed.
 
 Definition FreeLModule_functor a : LModules R := {freelmod R[a]}.
@@ -1724,7 +1744,7 @@ Local Notation forgetf := (forget_LModules_to_Sets R).
 Definition eta_fun a (x : a) : {freelmod R[a]} := [fm / x |-> 1].
 Definition eta : FId ~~> forgetf \o fm := eta_fun.
 Fact eta_natural : naturality FId (forgetf \o fm) eta.
-Proof. by move=> /= a b h x /=; rewrite /eta_fun FIdf hom_flm1. Qed.
+Proof. by move=> /= a b h x /=; rewrite /eta_fun FIdf freelmod_mor1. Qed.
 HB.instance Definition _ :=
   @isNatural.Build Sets Sets FId (forgetf \o fm) eta eta_natural.
 
@@ -1754,7 +1774,7 @@ Proof.
 move=> /= a b h.
 rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!linear_of_LmodE; apply: linear_fmE => /= x.
-rewrite FIdf /eps_fun /= hom_flm1.
+rewrite FIdf /eps_fun /= freelmod_mor1.
 by rewrite !finsupp_fm1 !big_seq_fset1 !fm1E !eqxx !scale1r.
 Qed.
 HB.instance Definition _ :=
@@ -1766,7 +1786,7 @@ Proof.
 move=> /= a.
 rewrite /FreeNModule_mor /eq_morphism /comp_morphism /=.
 rewrite -!linear_of_LmodE; apply: linear_fmE => /= x.
-rewrite /eta_fun /= /eps_fun /= hom_flm1.
+rewrite /eta_fun /= /eps_fun /= freelmod_mor1.
 by rewrite !finsupp_fm1 !big_seq_fset1 !fm1E !eqxx !scale1r.
 Qed.
 Fact triR : TriangularLaws.right eta eps.
@@ -1913,7 +1933,7 @@ Module ForgetSemiRings_to_Monoids.
 HB.instance Definition _ (R S : pzSemiRingType) (f : {rmorphism R -> S}) :=
   @isHom.Build Monoids (multMon R : Monoids) (multMon S : Monoids)
     (multMon_mor f : (_ : Monoids) -> _) (multMon_mor_monmorphism f).
-Definition functor_multMon_fun (R : SemiRings) : Monoids := multMon R.
+Definition multMon_obj (R : SemiRings) : Monoids := multMon R.
 Fact multMon_ext : FunctorLaws.ext (C := SemiRings) multMon_mor.
 Proof. by move=> /= a b f g eq y; rewrite /= /multMon_mor /= eq. Qed.
 Fact multMon_id : FunctorLaws.id (C := SemiRings) multMon_mor.
@@ -1922,9 +1942,10 @@ Fact multMon_comp  : FunctorLaws.comp (C := SemiRings) multMon_mor.
 Proof. by move=> /= a b c f g x; rewrite /multMon_mor /=. Qed.
 HB.instance Definition _ :=
   @isFunctor.Build SemiRings Monoids
-    functor_multMon_fun multMon_mor multMon_ext multMon_id multMon_comp.
-Definition functor : {functor SemiRings -> Monoids} := functor_multMon_fun.
+    multMon_obj multMon_mor multMon_ext multMon_id multMon_comp.
+Definition functor : {functor SemiRings -> Monoids} := multMon_obj.
 
+Definition multComMon_obj (R : ComSemiRings) : ComMonoids := multMon R.
 Definition multComMon_mor (R S : ComSemiRings) (f : {hom[ComSemiRings] R -> S})
   : (multMon R : ComMonoids) -> (multMon S : ComMonoids)
   := multMon_mor (rmorph_of_ComSemiRing f).  (* Why the coercion does't work *)
@@ -1932,7 +1953,6 @@ HB.instance Definition _ (R S : ComSemiRings) (f : {hom[ComSemiRings] R -> S}) :
   @isHom.Build ComMonoids (multMon R : ComMonoids) (multMon S : ComMonoids)
     (multComMon_mor f)
     (multMon_mor_monmorphism (rmorph_of_ComSemiRing f)).
-Definition functor_multComMon_fun (R : ComSemiRings) : ComMonoids := multMon R.
 Fact multComMon_ext : FunctorLaws.ext multComMon_mor.
 Proof. by move=> /= a b f g eq; exact: multMon_ext. Qed.
 Fact multComMon_id : FunctorLaws.id multComMon_mor.
@@ -1941,10 +1961,10 @@ Fact multComMon_comp  : FunctorLaws.comp multComMon_mor.
 Proof. by move=> /= a b c f g x; rewrite /multComMon_mor /multMon_mor. Qed.
 HB.instance Definition _ :=
   @isFunctor.Build ComSemiRings ComMonoids
-    functor_multComMon_fun multComMon_mor
+    multComMon_obj multComMon_mor
     multComMon_ext multComMon_id multComMon_comp.
 Definition functorCom : {functor ComSemiRings -> ComMonoids} :=
-  functor_multComMon_fun.
+  multComMon_obj.
 
 End ForgetSemiRings_to_Monoids.
 
@@ -2030,7 +2050,7 @@ apply: (functor_ext_hom (FreeLModule R)).
 by move=> {}c /=; rewrite mulmA.
 Qed.
 Lemma mul_mmacE a b r : mul_mma a [fm / b |-> r] = [fm / a * b |-> r].
-Proof. by rewrite /mul_mma /= hom_flmc. Qed.
+Proof. by rewrite /mul_mma /= freelmod_morc. Qed.
 
 Let mul_mma_fun x a := mul_mma a x.
 Definition mul_mar x : {hom[LModules R] {monalg R[M]} -> {monalg R[M]}} :=
@@ -2659,13 +2679,11 @@ Proof. exact: f_homcm. Qed.
 HB.instance Definition _  :=
   isHom.Build Monoids (M : Monoids) (N : Monoids) fm fm_homm.
 Definition fm_tmp : {hom[Monoids] M -> N} := fm.
-Definition ComMonoidAlgebra_fun : ({monalg R[M]} : ComAlgebras R)
+Definition cmonalg_mor : ({monalg R[M]} : ComAlgebras R)
              -> ({monalg R[N]} : ComAlgebras R) := MonoidAlgebra R # fm_tmp.
 HB.instance Definition _  :=
   @isHom.Build (ComAlgebras R) {monalg R[M]} {monalg R[N]}
-    ComMonoidAlgebra_fun (@hom_MonoidLAlgebra_is_lalg_morphism R M N fm).
-Definition ComMonoidAlgebra_mor_tmp :
-  {hom[ComAlgebras R] {monalg R[M]} -> {monalg R[N]}} := ComMonoidAlgebra_fun.
+    cmonalg_mor (@hom_MonoidLAlgebra_is_lalg_morphism R M N fm).
 
 End ComMonoidAlgebraHoms.
 
@@ -2677,7 +2695,7 @@ Variable R : ComRings.
 Definition forget_Hom_ComMonoid_to_Monoid M N (f : {hom[ComMonoids] M -> N}) :=
   fm_tmp (isHom_inhom f).
 Definition ComMonoidAlgebra_mor M N (f : {hom[ComMonoids] M -> N}) :=
-  ComMonoidAlgebra_mor_tmp R (isHom_inhom f).
+  cmonalg_mor (R := R) (isHom_inhom f).
 
 Fact ComMonoidAlgebra_ext : FunctorLaws.ext ComMonoidAlgebra_mor.
 Proof. by move=> M N f g eq; apply: MonoidAlgebra_ext. Qed.
@@ -2700,7 +2718,6 @@ HB.instance Definition _ :=
 End FunctorComMonoidAlgebra.
 Definition ComMonoidAlgebra (R : ComRings)
   : {functor ComMonoids -> ComAlgebras R} := ComMonoidAlgebra_functor R.
-
 
 
 (** Adjunction ComMonoid Algebras |- forget ComAlgebras to ComMonoids *)
@@ -2795,7 +2812,7 @@ Fact eps_natural : naturality (fMA \o forgetf) FId eps.
 Proof.
 move=> /= A B h x /=; rewrite FIdf -(fmE x); move: (finsupp x) => S.
 rewrite [eps_fun _]linear_sum /= -lrmorphism_of_ComAlgebrasE [LHS]linear_sum.
-rewrite -(lrmorphism_of_ComAlgebrasE (ComMonoidAlgebra_fun _)).
+rewrite -(lrmorphism_of_ComAlgebrasE (cmonalg_mor _)).
 rewrite [X in _ = eps_fun X]linear_sum [eps_fun _]linear_sum.
 apply eq_bigr => {S} a _ /=.
 rewrite eps_fun1E -[X in eps_fun (_ _ X)](fm1ZE _ (x _)).

--- a/theories/algcat.v
+++ b/theories/algcat.v
@@ -2081,7 +2081,7 @@ HB.instance Definition _ (A : Monoids) :=
 
 Lemma monalgE (A : Monoids) (T : Algebras R)
   (f g : {hom[Algebras R] {monalg R[A]} -> T}) :
-  (forall a : A, f [fm / a |-> 1] = g [fm / a |-> 1]) -> f =1 g.
+  (forall a : A, f [fm / a |-> 1] = g [fm / a |-> 1]) -> f =m= g.
 Proof.
 move=> eq x; rewrite -(lrmorphism_of_AlgebrasE f) -(lrmorphism_of_AlgebrasE g).
 exact: linear_fmE.
@@ -2258,7 +2258,7 @@ Lemma univmap_MonoidAlgebraP a : univmap_MonoidAlgebra [fm / a |-> 1] = \val (f 
 Proof. by rewrite -[in RHS](AdjointFunctors.hom_invK Adj _ _ f a). Qed.
 
 Lemma univmap_MonoidAlgebra_uniq (g : {hom[Algebras R] {monalg R[A]} -> M}) :
-  (forall a : A, g [fm / a |-> 1] = \val (f a)) -> g =1 univmap_MonoidAlgebra.
+  (forall a : A, g [fm / a |-> 1] = \val (f a)) -> g =m= univmap_MonoidAlgebra.
 Proof.
 move=> eq; apply: (AdjointFunctors.hom_iso_inj Adj).
 move=> a; rewrite AdjointFunctors.hom_invK.
@@ -2321,10 +2321,10 @@ Definition transf_multmon_to_Algebra : forgetMult ~> forget_Algebras_to_Sets R
               forget_Algebra_to_Semirings].
 
 Lemma transf_Algebra_to_multmonE A :
-  transf_Algebra_to_multmon A =1 transf_to_multmon A.
+  transf_Algebra_to_multmon A =m= transf_to_multmon A.
 Proof. by move=> a; rewrite /= !HCompId. Qed.
 Lemma transf_multmon_to_AlgebraE A :
-  transf_multmon_to_Algebra A =1 transf_from_multmon A.
+  transf_multmon_to_Algebra A =m= transf_from_multmon A.
 Proof. by move=> a; rewrite /= !HCompId. Qed.
 Lemma transf_Algebra_to_multmonK A :
   cancel (transf_Algebra_to_multmon A) (transf_multmon_to_Algebra A).
@@ -2468,10 +2468,6 @@ Definition forget_Hom_ComMonoid_to_Monoid A B (f : {hom[ComMonoids] A -> B}) :=
   fm_tmp (isHom_inhom f).
 Definition ComMonoidAlgebra_mor A B (f : {hom[ComMonoids] A -> B}) :=
   ComMonoidAlgebra_mor_tmp R (isHom_inhom f).
-
-Lemma ComMonoidAlgebra_morE A B (f : {hom[ComMonoids] A -> B}) :
-  ComMonoidAlgebra_mor f =1 MonoidAlgebra R # (forget_Hom_ComMonoid_to_Monoid f).
-Proof. by []. Qed.
 
 Fact ComMonoidAlgebra_ext : FunctorLaws.ext ComMonoidAlgebra_mor.
 Proof. by move=> M N f g eq; apply: MonoidAlgebra_ext. Qed.

--- a/theories/algcat.v
+++ b/theories/algcat.v
@@ -1613,6 +1613,7 @@ End UniversalProperty.
 
 
 Section FunctorialityInRing.
+(* shouldn't f be a {hom[Rings] R -> S} ??? *)
 Variable (A : Sets) (R S : Rings) (f : {rmorphism R -> S}).
 
 Definition homRing_FreeLModule (m : {freemod R[A]}) : {freemod S[A]} :=
@@ -1672,13 +1673,14 @@ Section HomRingFreeLModuleFunctor.
 Variables (A : Sets) (R S T : Rings).
 
 Fact homRing_FreeLModule_ext (f g : {rmorphism R -> S}) :
-  f =1 g -> homRing_FreeLModule f (A := A) =1 homRing_FreeLModule g (A := A).
+  f =m= g -> homRing_FreeLModule f (A := A) =m= homRing_FreeLModule g (A := A).
 Proof.
-move=> eq; apply: linear_fm_scaleE => /= [r x /= /[!eq] //|x].
+move=> eq; apply: linear_fm_scaleE => /= [r x /= |x].
+  by rewrite [f r](eq r).
 by rewrite !homRing_FreeLModuleP.
 Qed.
 Fact homRing_FreeLModule_id :
-  homRing_FreeLModule (A := A) (R := R) idfun =1 idfun.
+  homRing_FreeLModule (A := A) (R := R) idfun =m= idfun.
 Proof.
 move=> eq; apply: linear_fm_scaleE => //= x.
 by rewrite !homRing_FreeLModuleP.
@@ -1686,17 +1688,26 @@ Qed.
 
 Variables (f : {rmorphism R -> S}) (g : {rmorphism S -> T}).
 
+#[local] Notation comp :=
+  (homRing_FreeLModule g (A := A) \@ homRing_FreeLModule f (A := A)).
+
 Let comp := homRing_FreeLModule g (A := A) \@ homRing_FreeLModule f (A := A).
-HB.instance Definition _ := GRing.Additive.on comp.
 Let comp_is_scalable : scalable_for (g \o f \; *:%R) comp.
 Proof. by rewrite /comp => r x /=; rewrite !linearZ_LR /=. Qed.
-HB.instance Definition _ :=
-  GRing.isScalable.Build R {freemod R[A]} {freemod T[A]}
-    (g \o f \; *:%R) comp comp_is_scalable.
+
+(** Avoid declaring as a a canonical instance => non forgetful inheritance *)
+(** See: https://rocq-prover.zulipchat.com/#narrow/channel/237664-math-comp-users/topic/Linearity.20w.2Er.2Et.20change.20of.20scalar.20and.20compose.20map/near/610998680 *)
+Let fmadd := GRing.Additive.on comp.
+Let fmscal := GRing.isScalable.Build R {freemod R[A]} {freemod T[A]}
+                 (g \o f \; *:%R) (Hom.sort comp) comp_is_scalable.
+Definition comp_homRing_FreeLModule :
+  {linear {freemod R[A]} -> {freemod T[A]} | g \o f \; *:%R} :=
+      HB.pack (Hom.sort comp) fmadd fmscal.
+
 Fact homRing_FreeLModule_comp : comp =m= homRing_FreeLModule (g \o f) (A := A).
 Proof.
-apply: linear_fm_scaleE => //= x.
-by rewrite /comp /= !homRing_FreeLModuleP.
+apply: (linear_fm_scaleE (f := comp_homRing_FreeLModule)) => //= x.
+by rewrite !homRing_FreeLModuleP.
 Qed.
 
 End HomRingFreeLModuleFunctor.
@@ -2807,7 +2818,8 @@ Lemma homRing_FreeComAlgebra_uniq
   (g : {lrmorphism {freecalg R[A]} -> {freecalg S[A]} | f \; *:%R }) :
   (forall i, g (fcalg_gen R i) = fcalg_gen S i) -> g =m= homRing_FreeComAlgebra.
 Proof.
-move=> eqg x; rewrite -(freecalgE x) !linear_sum; apply: eq_bigr => i _.
+move=> eqg x; rewrite -(freecalgE x).
+rewrite [LHS]linear_sum [RHS]linear_sum; apply: eq_bigr => i _.
 rewrite !linearZ_LR !rmorph_prod /=; congr (_ *: _); apply: eq_bigr => a _.
 by rewrite eqg homRing_FreeComAlgebraP.
 Qed.
@@ -2869,7 +2881,8 @@ Lemma univmap_RingFreeComAlgebra_uniq
   (g : {lrmorphism {freecalg R[X]} -> A | fRm \; *:%R }) :
   (forall i : X, g (fcalg_gen R i) = fX i) -> g =m= univmap_RingFreeComAlgebra.
 Proof.
-move=> eqg a; rewrite -(freecalgE a) !linear_sum; apply eq_bigr => m _.
+move=> eqg a; rewrite -(freecalgE a).
+rewrite [LHS]linear_sum [RHS]linear_sum; apply eq_bigr => m _.
 rewrite !linearZ /=; congr (_ *: _).
 rewrite !rmorph_prod; apply: eq_bigr => {m} i _ /=.
 by rewrite eqg univmap_RingFreeComAlgebraP.

--- a/theories/algcat.v
+++ b/theories/algcat.v
@@ -14,6 +14,11 @@ Set SsrOldRewriteGoalsOrder.  (* change to Unset and remove the line when requir
 
 Import GRing.Theory.
 
+
+(* Help to rewrite with compositions *)
+#[local] Lemma compapp A B C (f : A -> B) (g : B -> C) (a : A) :
+  (g \o f) a = g (f a). Proof. by []. Qed.
+
 Local Open Scope category_scope.
 
 (* Sets *****************************************************************)

--- a/theories/category.v
+++ b/theories/category.v
@@ -760,10 +760,10 @@ Section equiv_cat_interface.
 
 Variables (C D : category) (F : {functor C -> D}) (G : {functor D -> C}).
 Variable (eq : equivalence_category F G).
-Definition eqFGId_map : (F \O G) ~~> FId := eqFGId eq.
-Definition eqGFId_map : (G \O F) ~~> FId := eqGFId eq.
-Definition eqIdFG_map : FId ~~> (F \O G) := fun a => inv_hom (eqFGId eq a).
-Definition eqIdGF_map : FId ~~> (G \O F) := fun a => inv_hom (eqGFId eq a).
+Let eqFGId_map : (F \O G) ~~> FId := eqFGId eq.
+Let eqGFId_map : (G \O F) ~~> FId := eqGFId eq.
+Let eqIdFG_map : FId ~~> (F \O G) := fun a => inv_hom (eqFGId eq a).
+Let eqIdGF_map : FId ~~> (G \O F) := fun a => inv_hom (eqGFId eq a).
 HB.instance Definition _ :=
   isNatural.Build D D (F \O G) FId eqFGId_map (natural_eqFGId eq).
 HB.instance Definition _ :=
@@ -1057,7 +1057,7 @@ End AdjComp.
 Export AdjComp.Exports.
 
 
-(** Adjonction through a natural isomorhism *)
+(** Adjonction through a natural isomorphism *)
 Module Adjoint_NatIsom.
 Section adjNatIsom.
 

--- a/theories/category.v
+++ b/theories/category.v
@@ -90,23 +90,14 @@ Delimit Scope category_scope with category.
 Local Open Scope category_scope.
 
 
-Lemma compfid A B (f : A -> B) : f \o id = f. Proof. by []. Qed.
-Lemma compidf A B (f : A -> B) : id \o f = f. Proof. by []. Qed.
 (* Help to rewrite with compositions *)
 Lemma compapp A B C (f : A -> B) (g : B -> C) (a : A) :
   (g \o f) a = g (f a). Proof. by []. Qed.
 Lemma idfunK A : cancel (@idfun A) idfun. Proof. by []. Qed.
-Lemma idfunE A a : (@idfun A a) = a. Proof. by []. Qed.
 
 (* opaque ssrfun.frefl blocks some proofs involving functor_ext *)
 #[global]
 Remove Hints frefl : core.
-
-Lemma frefl_transparent A B (f : A -> B) : f =1 f.
-Proof. by []. Defined.
-
-#[global]
-Hint Resolve frefl_transparent : core.
 
 (* Our categories are always concrete; morphisms are just functions. *)
 HB.mixin Record isCategory (obj : Type) := {
@@ -328,6 +319,20 @@ Proof. exact: homK. Qed.
 Lemma isom_invK (a b : C) (f : {isom a -> b}) : f \@ inv_hom f =m= idfun.
 Proof. exact: inv_homK. Qed.
 
+Lemma comp_isom_inj (a b c : C) (f : {isom a -> b}) (g1 g2 : {hom b -> c}) :
+  g1 \@ f =m= g2 \@ f -> g1 =m= g2.
+Proof.
+move=> eq; rewrite -(hom_compId g1) -(hom_compId g2) -(isom_invK f).
+by rewrite -!homcompA eq.
+Qed.
+
+Lemma isom_comp_inj (a b c : C) (f1 f2 : {hom a -> b}) (g : {isom b -> c}) :
+  g \@ f1 =m= g \@ f2 -> f1 =m= f2.
+Proof.
+move=> eq; rewrite -(hom_Idcomp f1) -(hom_Idcomp f2) -(isomK g).
+by rewrite !homcompA eq.
+Qed.
+
 End ismorphism_lemmas.
 
 HB.factory Record hasInverse (C : category) (a b : C) (f : el a -> el b)
@@ -387,7 +392,7 @@ Record eq_functor (C D : category)
   (F : {functor C -> D}) (G : {functor C -> D}) : Prop := EqFunctor {
     pm : F =1 G;
     eq_transport : forall (A B : C) (f : {hom A  -> B}),
-      transport_hom (pm A) (pm B) (F # f) =1 G # f
+      transport_hom (pm A) (pm B) (F # f) =m= G # f
   }.
 Notation "F =#= G" := (eq_functor F G).
 
@@ -423,8 +428,8 @@ Lemma eq_functor_trans (F G H : {functor C -> D}) :
   F =#= G -> G =#= H -> F =#= H.
 Proof.
 move=> [pmFG eqFG] [pmGH eqGH].
-apply: (functor_ext (eq := fun A => eq_trans (pmFG A) (pmGH A))) => A B f x.
-rewrite -transport_hom_trans -eqGH /=.
+apply: (functor_ext (eq := fun A => eq_trans (pmFG A) (pmGH A))) => A B f.
+rewrite -transport_hom_trans /= -eqGH /=.
 exact/transport_homE/eqFG.
 Qed.
 
@@ -432,9 +437,8 @@ Lemma eq_functor_sym (F G : {functor C -> D}) : F =#= G -> G =#= F.
 Proof.
 move=> [pm eq].
 apply: (functor_ext (eq := fun A => esym (pm A))) => A B f.
-apply (transport_hom_inj (pa := pm A) (pb := pm B)) => x.
-rewrite {}eq; move: x; rewrite -/(_ =1 _).
-move: (G # f) => {f}.
+apply (transport_hom_inj (pa := pm A) (pb := pm B)).
+rewrite {}eq; move: (G # f) => {f}.
 by case:_/(pm B); case:_/(pm A).
 Qed.
 
@@ -489,18 +493,17 @@ Definition functorcomposition a b :=
 
 Fact functorcomposition_ext : FunctorLaws.ext functorcomposition.
 Proof.
-move=> A B f g eq_fg x; rewrite /functorcomposition.
-by do 2 apply: functor_ext_hom.
+by move=> A B f g eq_fg; do 2 apply: functor_ext_hom.
 Qed.
 Fact functorcomposition_id : FunctorLaws.id functorcomposition.
 Proof.
-move=> A x; rewrite /functorcomposition [RHS]/=.
+rewrite /functorcomposition => A.
 rewrite (functor_ext_hom _ _ _ (functor_id (a := A))).
 exact: functor_id.
 Qed.
 Fact functorcomposition_comp : FunctorLaws.comp functorcomposition.
 Proof.
-move=> a b c g h x; rewrite /functorcomposition.
+rewrite /functorcomposition => a b c g h.
 rewrite (functor_ext_hom _ _ _ (functor_comp_hom _ _ _ _ _)).
 exact: functor_comp_hom.
 Qed.
@@ -583,10 +586,10 @@ Notation "p =%= q" := (eq_nattrans p q).
 Lemma eq_nattrans_refl (phi : F ~> G) : phi =%= phi.
 Proof. by []. Qed.
 Lemma eq_nattrans_sym (phi psi : F ~> G) : phi =%= psi -> psi =%= phi.
-Proof. by move=> eq a x /[!eq]. Qed.
+Proof. by move=> eq a /[!eq]. Qed.
 Lemma eq_nattrans_trans (phi psi ksi : F ~> G) :
   phi =%= psi -> psi =%= ksi -> phi =%= ksi.
-Proof. by move=> eqp eqk a x /[!eqp] /[!eqk]. Qed.
+Proof. by move=> eqp eqk a /[!eqp] /[!eqk]. Qed.
 
 Add Parametric Relation : (F ~> G) eq_nattrans
     reflexivity proved by eq_nattrans_refl
@@ -651,10 +654,10 @@ Lemma natural_inv (C D : category) (F G : {functor C -> D})
   (T : forall a, {isom F a -> G a}) :
   naturality F G T -> naturality G F (fun a => inv_hom (T a)).
 Proof.
-move=> T_nat A B f x; apply: (can_inj (homK (T B))).
+move=> T_nat A B f; apply: (isom_comp_inj (g := T B)).
 pose Tn := Natural.Pack (Natural.Class (isNatural.Build C D F G T T_nat)).
-have /= <- := natural_head Tn A B _ f (inv_hom (T A)) x.
-by rewrite !inv_homK.
+have /= <- := natural_head Tn A B _ f (inv_hom (T A)).
+by rewrite isom_invK -homcompA isom_invK hom_compId hom_Idcomp.
 Qed.
 
 
@@ -849,11 +852,13 @@ Definition fun_eqIdFG (e : E) : _ -> _ := trans_eqIdFG e.
 
 Fact fun_eqFGIdK (e : E) : cancel (@fun_eqFGId e) (@fun_eqIdFG e).
 Proof.
+(* TODO: point-free proof ? *)
 move=> x; rewrite /fun_eqFGId /fun_eqIdFG /= homK !HCompId !HIdComp.
 by rewrite -functor_inv_homE homK.
 Qed.
 Fact fun_eqIdFGK (e : E) : cancel (trans_eqIdFG e) (trans_eqFGId e).
 Proof.
+(* TODO: point-free proof ? *)
 move=> x; rewrite /fun_eqFGId /fun_eqIdFG /= !HCompId !HIdComp /=.
 by rewrite -functor_inv_homE !inv_homK.
 Qed.
@@ -878,11 +883,13 @@ Definition fun_eqIdGF (c : C) : _ -> _ := trans_eqIdGF c.
 
 Fact fun_eqGFIdK (c : C) : cancel (@fun_eqGFId c) (@fun_eqIdGF c).
 Proof.
+(* TODO: point-free proof ? *)
 move=> x; rewrite /fun_eqGFId /fun_eqIdGF /= homK !HCompId !HIdComp.
 by rewrite -functor_inv_homE homK.
 Qed.
 Fact fun_eqIdGFK (c : C) : cancel (@fun_eqIdGF c) (@fun_eqGFId c).
 Proof.
+(* TODO: point-free proof ? *)
 move=> x; rewrite /fun_eqGFId /fun_eqIdGF /= !HCompId !HIdComp.
 by rewrite -functor_inv_homE FCompE FIdf /= !inv_homK.
 Qed.
@@ -1022,8 +1029,10 @@ Definition Eta : FId ~> G \O F :=
     \v [NEq G0 \O F0 , G0 \O FId \O F0]
     \v eta0.
 Lemma EtaE a : Eta a =m= G0 # (eta1 (F0 a)) \@ (eta0 a).
+(* TODO: point-free proof ? *)
 Proof. by move=> x /=; rewrite HCompId HIdComp. Qed.
 Lemma EtaE_hom a : Eta a =m= G0 # (eta1 (F0 a)) \@ (eta0 a).
+(* TODO: point-free proof ? *)
 Proof. by move=> x; rewrite EtaE. Qed.
 
 Definition Eps : F \O G ~> FId :=
@@ -1032,8 +1041,10 @@ Definition Eps : F \O G ~> FId :=
     \v (NId F1 \h eps0 \h NId G1)
     \v [NEq F \O G , (F1 \O (F0 \O G0)) \O G1].
 Lemma EpsE a : Eps a =m= (eps1 _) \@ F1 # (eps0 (G1 a)).
+(* TODO: point-free proof ? *)
 Proof. by move=> x /=; rewrite HCompId HIdComp. Qed.
 Lemma EpsE_hom a : Eps a =m= (eps1 _) \@ F1 # (eps0 (G1 a)).
+(* TODO: point-free proof ? *)
 Proof. by move=> x; rewrite EpsE. Qed.
 
 Lemma triL : TriangularLaws.left Eta Eps.
@@ -1102,6 +1113,7 @@ move: (AdjointFunctors.eps adj) => eps.
 move: (AdjointFunctors.eta adj) => eta <-.
 rewrite !VCompE homcompA HIdComp /= -functor_o.
 rewrite HCompId -homcompA.
+(* TODO: point-free proof ? *)
 have -> : G'G (F A) \@ GG' (F A) =m= idfun by move=> x /=; rewrite GG'K.
 by rewrite functor_o functor_id hom_Idcomp.
 Qed.
@@ -1115,6 +1127,7 @@ move: (AdjointFunctors.eta adj) => eta triR.
 rewrite !(HIdComp, HCompId, VCompE) /= functor_o !homcompA.
 rewrite (natural_head GG' (F (G' A))) -FCompE (natural eta) FIdf.
 rewrite (natural_head GG') -(homcompA (G # _)) triR.
+(* TODO: point-free proof ? *)
 by rewrite hom_Idcomp => x /=; rewrite G'GK.
 Qed.
 
@@ -1159,12 +1172,12 @@ Fact associative_aux x y z (f : {hom x -> M y}) (g : {hom y -> M z}) :
   (fun w => (f w >>= g)) =1 (b g \@ f).
 Proof. by []. Qed.
 Definition associative :=
-  forall A B C (m : el (M A)) (f : {hom A -> M B}) (g : {hom B -> M C}),
-  (m >>= f) >>= g = m >>= (b g \@ f).
+  forall A B C (f : {hom A -> M B}) (g : {hom B -> M C}),
+       b g \@ b f =m= b (b g \@ f).
 Definition left_neutral (r : forall A, {hom A -> M A}) :=
-  forall A B (f : {hom A -> M B}), (b f \@ r A) =m= f.
+  forall A B (f : {hom A -> M B}), b f \@ r A =m= f.
 Definition right_neutral (r : forall A, {hom A -> M A}) :=
-  forall A (m : el (M A)), m >>= r _ = m.
+  forall A, b (r A) =m= idfun.
 End bindlaws.
 End BindLaws.
 
@@ -1175,10 +1188,18 @@ Variables (C : category) (M : C -> C).
 Variable b : forall A B, {hom A -> M B} -> {hom M A -> M B}.
 Local Notation "m >>= f" := (b f m).
 
-Lemma bind_left_neutral_hom_fun (r : forall A, {hom A -> M A})
-  : BindLaws.left_neutral b r
-    <-> forall A B (f : {hom A -> M B}), b f \@ r A =m= f.
-Proof. by split; move=> H A B f; exact: (H A B f). Qed.
+Lemma bind_left_neutral_hom_fun (r : forall A, {hom A -> M A}) :
+  BindLaws.left_neutral b r
+  <-> forall A B (f : {hom A -> M B}), (b f \@ r A) =m= f.
+Proof. by []. Qed.
+Lemma bind_right_neutral_hom_fun (r : forall A, {hom A -> M A}) :
+  BindLaws.right_neutral b r <-> forall A (m : el (M A)), m >>= r _ = m.
+Proof. by []. Qed.
+Lemma associative_hom_fun :
+  BindLaws.associative b
+  <-> forall A B C (m : el (M A)) (f : {hom A -> M B}) (g : {hom B -> M C}),
+  (m >>= f) >>= g = m >>= (b g \@ f).
+Proof. by split => [H U V W m f g | H U V W f g m]; exact: H. Qed.
 
 End bind_lemmas.
 
@@ -1209,8 +1230,6 @@ Variable (C : category) (M : monad C).
 (* *_head lemmas are for [fun of f] \o ([fun of g] \o ([fun of h] \o ..))*)
 
 Import comps_notation.
-(* *_head lemmas are for [fun of f] \o ([fun of g] \o ([fun of h] \o ..))*)
-Import comps_notation.
 Lemma joinretM_head a (c : C) (f : {hom c -> M a}) :
   [\@ join _, ret _, f] =m= f.
 Proof. by rewrite -homcompA joinretM. Qed.
@@ -1238,7 +1257,7 @@ Let bind (a b : C) (f : {hom a -> M b}) : {hom M a -> M b} :=
       join _ \@ (F # f).
 Let bind_ext (a b : C) (f g : {hom a -> M b}) :
   f =m= g -> bind f =m= bind g.
-Proof. by rewrite /bind => eq x /=; rewrite (functor_ext_hom _ _ _ eq). Qed.
+Proof. by rewrite /bind => /functor_ext_hom ->. Qed.
 Let bindE (a b : C) (f : {hom a -> M b}) (m : el (M a)) :
     bind f m = join b (([the {functor C -> C} of M] # f) m).
 Proof. by []. Qed.
@@ -1263,20 +1282,14 @@ Let bindretf_fun : (forall (a b : C) (f : {hom a -> M b}),
   bind f \@ ret' a =m= f).
 Proof. by apply/bind_left_neutral_hom_fun/bindretf. Qed.
 Let fmap_id : FunctorLaws.id fmap.
-Proof.
-move=> A m; rewrite /fmap /idfun -[in RHS](bindmret m).
-by apply: bind_ext_hom.
-Qed.
+Proof. by move=> A; rewrite /fmap bind_ext_hom; last exact: bindmret. Qed.
 Let fmap_ext : FunctorLaws.ext fmap.
-Proof.
-by move=> A B f g eq; rewrite /fmap; apply: bind_ext_hom => x /= /[!eq].
-Qed.
+Proof. by move=> A B f g eq; apply: bind_ext_hom; rewrite /= eq. Qed.
 Let fmap_o : FunctorLaws.comp fmap.
 Proof.
-move=> a b c g h x; rewrite /fmap.
-rewrite [RHS]bindA/=; apply: bind_ext_hom => {}x /=.
-rewrite !hom_compE homcompA; apply: esym.
-exact: bindretf_fun.
+move=> a b c g h; rewrite /fmap.
+rewrite [X in _ =m= X]bindA/=; apply: bind_ext_hom.
+by rewrite -!homcompA bindretf_fun.
 Qed.
 HB.instance Definition _ := isFunctor.Build C C M fmap_ext fmap_id fmap_o.
 Notation F := [the {functor _ -> _} of M].
@@ -1287,47 +1300,41 @@ HB.instance Definition _ := isNatural.Build _ _ FId F
   (ret' : FId ~~> M)(*NB: fails without this type constraint*) ret'_naturality.
 Definition ret := [the FId ~> F of ret'].
 Let join' : F \O F ~~> F := fun _ => bind [hom idfun].
-Let fmap_bind a b c (f : {hom a ->b}) m (g : {hom c ->F a}) :
-  (fmap f) (bind g m) = bind (fmap f \@ g) m.
+Let fmap_bind a b c (f : {hom a ->b}) (g : {hom c ->F a}) :
+  (fmap f) \@ (bind g) =m= bind (fmap f \@ g).
 Proof. by rewrite /fmap bindA. Qed.
 Let join'_naturality : naturality (F \O F) F join'.
 Proof.
-move=> A B h m; rewrite /join /=.
-rewrite fmap_bind bindA; apply: bind_ext_hom => {}m /=.
-rewrite !hom_compE homcompA; apply: esym.
-exact: bindretf_fun.
+move=> A B h; rewrite /join /=.
+rewrite fmap_bind bindA; apply: bind_ext_hom.
+by rewrite -!homcompA bindretf_fun.
 Qed.
 HB.instance Definition _ := isNatural.Build _ _ _ _ _ join'_naturality.
 Definition join := [the F \O F ~> F of join'].
 
-Let bind_fmap a b c (f : {hom a -> b}) (m : el (F a)) (g : {hom b -> F c}) :
-  bind g (fmap f m) = bind (g \@ f) m .
+Let bind_fmap a b c (f : {hom a -> b}) (g : {hom b -> F c}) :
+  bind g \@ (fmap f) =m= bind (g \@ f).
 Proof.
-rewrite bindA /=; apply: bind_ext_hom => {}m /=.
-rewrite !hom_compE homcompA /=.
-exact: bindretf_fun.
+rewrite bindA /=; apply: bind_ext_hom.
+by rewrite -!homcompA bindretf_fun.
 Qed.
-Lemma bindE (a b : C) (f : {hom a -> F b}) (m : el (F a)) :
-  bind f m = join b (([the {functor C -> C} of F] # f) m).
-Proof. by rewrite /join /= bind_fmap /=; apply: bind_ext_hom. Qed.
+Lemma bindE (a b : C) (f : {hom a -> F b}) : bind f =m= join b \@ F # f.
+Proof. by rewrite /join /= bind_fmap; apply: bind_ext_hom. Qed.
 Lemma joinretM : JoinLaws.left_unit ret join.
 Proof.
 rewrite /join => A m /=; rewrite !hom_compE.
 exact: bindretf_fun.
 Qed.
-Let bind_fmap_fun a b c (f : {hom a ->b}) (g : {hom b -> F c}) :
-  bind g \@ fmap f =m= bind (g \@ f).
-Proof. by move=> m; exact: bind_fmap. Qed.
 Lemma joinMret : JoinLaws.right_unit ret join.
 Proof.
-rewrite /join => A ma /=; rewrite !hom_compE.
-rewrite bind_fmap_fun/= -[in RHS](bindmret ma) /=.
+rewrite /join => A /=.
+rewrite bind_fmap -[X in _ =m= X]bindmret.
 exact: bind_ext_hom.
 Qed.
 Lemma joinA : JoinLaws.associativity join.
 Proof.
-move => A mmma; rewrite /join.
-rewrite bind_fmap_fun/= bindA/=.
+move=> A; rewrite /join /=.
+rewrite bind_fmap /= bindA /=.
 exact: bind_ext_hom.
 Qed.
 HB.instance Definition _ :=
@@ -1351,12 +1358,12 @@ Let triL := AdjointFunctors.triL A.
 Let triR := AdjointFunctors.triR A.
 
 Lemma naturality_ret : naturality FId M ret.
-Proof. by move=> a b f x; rewrite (natural eta). Qed.
+Proof. by move=> a b f; rewrite (natural eta). Qed.
 HB.instance Definition _ := isNatural.Build C C FId M ret naturality_ret.
 Lemma naturality_join : naturality (M \O M) M join.
 Proof.
-rewrite /join => a b h x.
-rewrite /M !FCompE -2!(@functor_o _ _ G) /=; apply: functor_ext_hom => {}x.
+rewrite /join => a b h.
+rewrite /M !FCompE -2!(@functor_o _ _ G) /=; apply: functor_ext_hom.
 exact: (natural eps).
 Qed.
 HB.instance Definition _ := isNatural.Build C C (M \O M) M join naturality_join.
@@ -1365,13 +1372,14 @@ Let joinE : join = fun a => G # (@eps (F a)).
 Proof. by []. Qed.
 Let join_associativity' a : join a \@ join (M a) =m= join a \@ (M # join a).
 Proof.
-move=> x; rewrite joinE -2!(@functor_o _ _ G) /=; apply: functor_ext_hom => {}x /=.
+rewrite joinE -2!(@functor_o _ _ G) /=.
+apply: functor_ext_hom.
 exact: (natural eps).
 Qed.
 Lemma join_associativity : JoinLaws.associativity join.
-Proof. by move=> a x; rewrite join_associativity'. Qed.
+Proof. by move=> a; rewrite join_associativity'. Qed.
 Lemma join_left_unit : JoinLaws.left_unit ret join.
-Proof. by move=> a x; rewrite joinE triR. Qed.
+Proof. by move=> a; rewrite joinE triR. Qed.
 Lemma join_right_unit :JoinLaws.right_unit ret join.
 Proof.
 move=> a; rewrite joinE /M FCompE /=.

--- a/theories/category.v
+++ b/theories/category.v
@@ -1247,7 +1247,10 @@ Let bindretf_fun : (forall (a b : C) (f : {hom a -> M b}),
   bind f \@ ret' a =m= f).
 Proof. by apply/bind_left_neutral_hom_fun/bindretf. Qed.
 Let fmap_id : FunctorLaws.id fmap.
-Proof. by move=> A; rewrite /fmap bind_ext_hom; last exact: bindmret. Qed.
+Proof.
+move=> A; rewrite /fmap (bind_ext_hom (hom_compId (ret' A))).
+exact: bindmret.
+Qed.
 Let fmap_ext : FunctorLaws.ext fmap.
 Proof. by move=> A B f g eq; apply: bind_ext_hom; rewrite /= eq. Qed.
 Let fmap_o : FunctorLaws.comp fmap.

--- a/theories/category.v
+++ b/theories/category.v
@@ -90,11 +90,6 @@ Delimit Scope category_scope with category.
 Local Open Scope category_scope.
 
 
-(* Help to rewrite with compositions *)
-Lemma compapp A B C (f : A -> B) (g : B -> C) (a : A) :
-  (g \o f) a = g (f a). Proof. by []. Qed.
-Lemma idfunK A : cancel (@idfun A) idfun. Proof. by []. Qed.
-
 (* opaque ssrfun.frefl blocks some proofs involving functor_ext *)
 #[global]
 Remove Hints frefl : core.
@@ -178,14 +173,6 @@ Lemma homcompA (a b c d : C)
   (h \@ g) \@ f =m= h \@ (g \@ f).
 Proof. by []. Qed.
 
-Lemma homcompE (a b c : C) (g : {hom b -> c}) (f : {hom a -> b}) :
-  g \@ f =1 g \o f :> (el a -> el c).
-Proof. by []. Qed.
-
-Lemma hom_compE (a b c : C) (g : {hom b -> c}) (f : {hom a -> b}) x :
-  g (f x) = (g \@ f) x.
-Proof. by [].  Qed.
-
 Lemma hom_compId (a b : C) (f : {hom a -> b}) : f \@ idfun =m= f.
 Proof. by []. Qed.
 Lemma hom_Idcomp (a b : C) (f : {hom a -> b}) : idfun \@ f =m= f.
@@ -193,26 +180,6 @@ Proof. by []. Qed.
 
 
 Import comps_notation.
-
-(* Restricting the components of a composition to homs and using the lemma
-   homcompA, we can avoid the infinite sequence of redundunt compositions
-   "_ \o id" or "id \o _" that pops out when we "rewrite !compA".*)
-Lemma hom_compA (a b c d : C)
-  (h : {hom c -> d}) (g : {hom b -> c}) (f : {hom a -> b}) :
-  (h \@ g) \@ f =m= [\@ h, g, f].
-Proof. exact: homcompA. Qed.
-
-Example hom_compA' (a b c d : C)
-  (h : {hom c -> d}) (g : {hom b -> c}) (f : {hom a -> b}) :
-  (h \@ g) \@ f =m= [\@ h, g, f].
-Proof. by []. Qed.
-
-(* Tactic support is desirable for the following two cases :
-   1. rewriting at the head of the sequence;
-      compare for example the lemmas natural and natural_head below
-   2. rewriting under [hom _];
-      dependent type errors and explicit application of hom_ext is tedious.
-*)
 
 End category_lemmas.
 
@@ -250,18 +217,14 @@ Add Parametric Morphism  (a a' b b' : C) (pa : a = a') (pb : b = b') :
     with signature (@eq_morphism C b a) ==> (@eq_morphism C b' a')
       as transport_homE.
 Proof. by subst a b. Qed.
-(*
-Lemma transport_homE (a a' b b' : C) (pa : a = a') (pb : b = b')
-  (f g : {hom a -> b}) :
-  f =m= g -> transport_hom pa pb f =m= transport_hom pa pb g.
-Proof. by subst a b. Qed.
-*)
+
 Lemma transport_hom_inj (a a' b b' : C) (pa : a = a') (pb : b = b')
   (f g : {hom a -> b}) :
   transport_hom pa pb f =m= transport_hom pa pb g -> f =m= g.
 Proof. by subst a b. Qed.
 Lemma transport_hom_trans (a a' a'' b b' b'' : C)
-  (pa : a = a') (pa' : a' = a'') (pb : b = b') (pb' : b' = b'') (f : {hom a -> b}) :
+      (pa : a = a') (pa' : a' = a'') (pb : b = b') (pb' : b' = b'')
+      (f : {hom a -> b}) :
   (transport_hom pa' pb' \o transport_hom pa pb) f =m=
     transport_hom (eq_trans pa pa') (eq_trans pb pb') f.
 Proof. by subst a a' b b'. Qed.
@@ -289,6 +252,8 @@ Arguments inv_homK [C a b].
 Section isom_interface.
 Variable C : category.
 Implicit Types a b c : C.
+
+#[local] Lemma idfunK A : cancel (@idfun A) idfun. Proof. by []. Qed.
 
 HB.instance Definition _ c :=
   isIsom.Build _ _ _ (@idfun (el c))
@@ -578,7 +543,7 @@ Variables (C D : category) (F G : {functor C -> D}).
 
 Lemma natural_head (phi : F ~> G) a b c (h : {hom a -> b}) (f : {hom c -> F a}) :
   [\@ G # h, phi a, f] =m= [\@ phi b, F # h, f].
-Proof. by rewrite -!hom_compA (natural phi). Qed.
+Proof. by rewrite -!homcompA (natural phi). Qed.
 
 Definition eq_nattrans (phi psi : F ~> G) := forall a : C, (phi a =m= psi a).
 Notation "p =%= q" := (eq_nattrans p q).
@@ -1056,7 +1021,7 @@ evar (TY : Type).
 evar (Y : TY).
 have -> : X =m= Y by rewrite /X -(natural eps0) => x; apply: erefl.
 rewrite (functor_o_head F1) FIdf.
-rewrite -!hom_compA triL1 hom_Idcomp.
+rewrite -!homcompA triL1 hom_Idcomp.
 by rewrite -(functor_o F1) triL0 functor_id.
 Qed.
 
@@ -1072,7 +1037,7 @@ evar (TY : Type).
 evar (Y : TY).
 have -> : G0 # X =m= G0 # Y
   by rewrite /X /= (natural eta1) => x; exact: erefl.
-rewrite (functor_o G0) hom_compA FIdf triR0 hom_compId.
+rewrite (functor_o G0) homcompA FIdf triR0 hom_compId.
 by rewrite -(functor_o G0) triR1 functor_id.
 Qed.
 
@@ -1322,7 +1287,7 @@ Lemma bindE (a b : C) (f : {hom a -> F b}) : bind f =m= join b \@ F # f.
 Proof. by rewrite /join /= bind_fmap; apply: bind_ext_hom. Qed.
 Lemma joinretM : JoinLaws.left_unit ret join.
 Proof.
-rewrite /join => A m /=; rewrite !hom_compE.
+rewrite /join => A /=.
 exact: bindretf_fun.
 Qed.
 Lemma joinMret : JoinLaws.right_unit ret join.

--- a/theories/category.v
+++ b/theories/category.v
@@ -1,6 +1,7 @@
 (* Categories for the working MathComp developpers                            *)
 (* Copyright (C) 2020 monae authors, 2024-2026 Florent Hivert,                *)
 (* license: LGPL-3.0-or-later                                                 *)
+From Corelib Require Import Setoid.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
 From mathcomp Require Import choice fintype finfun bigop.
@@ -63,9 +64,11 @@ Unset Printing Implicit Defensive.
 Declare Scope category_scope.
 
 Reserved Notation "f \O g" (at level 50, format "f  \O  g").
+Reserved Notation "f \@ g" (at level 50, format "f  \@  g").
 Reserved Notation "F ~~> G" (at level 51).
 Reserved Notation "f ~> g" (at level 51).
 Reserved Notation "F # g" (at level 11).
+Reserved Notation "F =m= g" (at level 70, no associativity).
 Reserved Notation "F =#= g" (at level 70, no associativity).
 Reserved Notation "F =%= g" (at level 70, no associativity).
 Reserved Notation "F -| G" (at level 51, G at next level).
@@ -94,7 +97,6 @@ Lemma compapp A B C (f : A -> B) (g : B -> C) (a : A) :
   (g \o f) a = g (f a). Proof. by []. Qed.
 Lemma idfunK A : cancel (@idfun A) idfun. Proof. by []. Qed.
 Lemma idfunE A a : (@idfun A a) = a. Proof. by []. Qed.
-
 
 (* opaque ssrfun.frefl blocks some proofs involving functor_ext *)
 #[global]
@@ -148,11 +150,31 @@ HB.instance Definition _ (a b c : C) (f : {hom b -> c}) (g : {hom a -> b}):=
   isHom.Build _ _ _ (f \o g) (funcomp_inhom (isHom_inhom g) (isHom_inhom f)).
 End hom_interface.
 
+Definition eq_morphism (C : category) (B A : C) (f g : {hom A -> B}) := f =1 g.
+Definition comp_morphism (C : category) (U V W : C) :
+  {hom V -> U} -> {hom W -> V} -> {hom W -> U} := @comp (el U) (el V) (el W).
+
+Notation "f =m= g" := (eq_morphism f g).
+Notation "f \@ g" := (comp_morphism f g).
+
 (* Notation [\o f , .. , g , h] for hom compositions. *)
 Module comps_notation.
-Notation "[ '\o' f , .. , g , h ]" := (f \o .. (g \o h) ..) (at level 0,
-  format "[ '[' '\o'  f ,  '/' .. ,  '/' g ,  '/' h ']' ]") : category_scope.
+Notation "[ '\@' f , .. , g , h ]" := (f \@ .. (g \@ h) ..) (at level 0,
+  format "[ '[' '\@'  f ,  '/' .. ,  '/' g ,  '/' h ']' ]") : category_scope.
 End comps_notation.
+
+Add Parametric Relation (C : category) (A B : C) :
+  {hom A -> B} (@eq_morphism C B A)
+    reflexivity proved by (fun _ _ => erefl _)
+    symmetry proved by (@fsym (el B) (el A))
+    transitivity proved by (@ftrans (el B) (el A))
+    as eq_mor.
+Add Parametric Morphism  (C : category) (U V W : C) :
+  (@comp_morphism C U V W : {hom V -> U} -> {hom W -> V} -> {hom W -> U})
+    with signature
+    (@eq_morphism C U V) ==> (@eq_morphism C V W) ==> (@eq_morphism C U W)
+      as comp_mor.
+Proof. by move=> /= f1 f2 eqf g1 g2 eqg x; rewrite /= eqg eqf. Qed.
 
 Section category_lemmas.
 Variable C : category.
@@ -162,16 +184,22 @@ Proof. by []. Qed.
 
 Lemma homcompA (a b c d : C)
   (h : {hom c -> d}) (g : {hom b -> c}) (f : {hom a -> b}) :
-  [hom [hom h \o g] \o f] =1 [hom h \o [hom g \o f]].
+  (h \@ g) \@ f =m= h \@ (g \@ f).
 Proof. by []. Qed.
 
 Lemma homcompE (a b c : C) (g : {hom b -> c}) (f : {hom a -> b}) :
-  [hom g \o f] =1 g \o f :> (el a -> el c).
+  g \@ f =1 g \o f :> (el a -> el c).
 Proof. by []. Qed.
 
 Lemma hom_compE (a b c : C) (g : {hom b -> c}) (f : {hom a -> b}) x :
-  g (f x) = (g \o f) x.
+  g (f x) = (g \@ f) x.
 Proof. by [].  Qed.
+
+Lemma hom_compId (a b : C) (f : {hom a -> b}) : f \@ idfun =m= f.
+Proof. by []. Qed.
+Lemma hom_Idcomp (a b : C) (f : {hom a -> b}) : idfun \@ f =m= f.
+Proof. by []. Qed.
+
 
 Import comps_notation.
 
@@ -180,12 +208,12 @@ Import comps_notation.
    "_ \o id" or "id \o _" that pops out when we "rewrite !compA".*)
 Lemma hom_compA (a b c d : C)
   (h : {hom c -> d}) (g : {hom b -> c}) (f : {hom a -> b}) :
-  (h \o g) \o f =1 [\o h, g, f] :> (el a -> el d).
+  (h \@ g) \@ f =m= [\@ h, g, f].
 Proof. exact: homcompA. Qed.
 
 Example hom_compA' (a b c d : C)
   (h : {hom c -> d}) (g : {hom b -> c}) (f : {hom a -> b}) :
-  (h \o g) \o f = [\o h, g, f].
+  (h \@ g) \@ f =m= [\@ h, g, f].
 Proof. by []. Qed.
 
 (* Tactic support is desirable for the following two cases :
@@ -217,26 +245,33 @@ Definition hom_of_eq (a b : C) (p : a = b) : {hom a -> b} :=
 
 (* F for factorization *)
 Lemma transport_domF (a a' b : C) (p : a = a') (f : {hom a -> b}) :
-  transport_dom p f =1 [hom f \o hom_of_eq (esym p)].
+  transport_dom p f =m= f \@ hom_of_eq (esym p).
 Proof. by subst a'. Qed.
 Lemma transport_codomF (a b b' : C) (p : b = b') (f : {hom a -> b}) :
-  transport_codom p f =1 [hom hom_of_eq p \o f].
+  transport_codom p f =m= hom_of_eq p \@ f.
 Proof. by subst b'. Qed.
 Lemma transport_homF (a a' b b' : C) (pa : a = a') (pb : b = b') (f : {hom a -> b}) :
-  transport_hom pa pb f =1 [hom hom_of_eq pb \o f \o hom_of_eq (esym pa)].
+  transport_hom pa pb f =m= hom_of_eq pb \@ f \@ hom_of_eq (esym pa).
 Proof. by subst a' b'. Qed.
 
+Add Parametric Morphism  (a a' b b' : C) (pa : a = a') (pb : b = b') :
+  (transport_hom pa pb)
+    with signature (@eq_morphism C b a) ==> (@eq_morphism C b' a')
+      as transport_homE.
+Proof. by subst a b. Qed.
+(*
 Lemma transport_homE (a a' b b' : C) (pa : a = a') (pb : b = b')
   (f g : {hom a -> b}) :
-  f =1 g -> transport_hom pa pb f =1 transport_hom pa pb g.
+  f =m= g -> transport_hom pa pb f =m= transport_hom pa pb g.
 Proof. by subst a b. Qed.
+*)
 Lemma transport_hom_inj (a a' b b' : C) (pa : a = a') (pb : b = b')
   (f g : {hom a -> b}) :
-  transport_hom pa pb f =1 transport_hom pa pb g -> f =1 g.
+  transport_hom pa pb f =m= transport_hom pa pb g -> f =m= g.
 Proof. by subst a b. Qed.
 Lemma transport_hom_trans (a a' a'' b b' b'' : C)
   (pa : a = a') (pa' : a' = a'') (pb : b = b') (pb' : b' = b'') (f : {hom a -> b}) :
-  (transport_hom pa' pb' \o transport_hom pa pb) f =1
+  (transport_hom pa' pb' \o transport_hom pa pb) f =m=
     transport_hom (eq_trans pa pa') (eq_trans pb pb') f.
 Proof. by subst a a' b b'. Qed.
 
@@ -287,13 +322,28 @@ Variable C : category.
 Lemma isom_bij (a b : C) (f : {isom a -> b}) : bijective f.
 Proof. by exists (inv_hom f); [exact: homK | exact: inv_homK]. Qed.
 
-Lemma isomK (a b : C) (f : {isom a -> b}) : cancel f (inv_hom f).
+Lemma isomK (a b : C) (f : {isom a -> b}) : inv_hom f \@ f =m= idfun.
 Proof. exact: homK. Qed.
 
-Lemma isom_invK (a b : C) (f : {isom a -> b}) : cancel (inv_hom f) f.
+Lemma isom_invK (a b : C) (f : {isom a -> b}) : f \@ inv_hom f =m= idfun.
 Proof. exact: inv_homK. Qed.
 
 End ismorphism_lemmas.
+
+HB.factory Record hasInverse (C : category) (a b : C) (f : el a -> el b)
+  of isHom C a b f := {
+    mkinv : {hom b -> a};
+    mkhomK : mkinv \@ f =m= idfun;
+    mkinvK : f \@ mkinv =m= idfun;
+  }.
+HB.builders Context C a b f of hasInverse C a b f.
+Lemma isom_mkhomK : cancel f mkinv.
+Proof. exact: mkhomK. Qed.
+Lemma isom_mkinvK : cancel mkinv f.
+Proof. exact: mkinvK. Qed.
+HB.instance Definition _:=
+  isIsom.Build C a b f (isHom_inhom mkinv) isom_mkhomK isom_mkinvK.
+HB.end.
 
 
 Module FunctorLaws.
@@ -301,11 +351,11 @@ Section def.
 Variable (C D : category).
 Variable (F : C -> D) (actm : forall a b, {hom a -> b} -> {hom F a -> F b}).
 Definition ext := forall a b (f g : {hom a -> b}),
-    f =1 g -> actm f =1 actm g.
+    f =m= g -> actm f =m= actm g.
 Definition id := forall a,
-    actm [hom idfun] =1 [hom idfun] :> {hom F a -> F a}.
+    actm [hom idfun] =m= ([hom idfun] : {hom F a -> F a}).
 Definition comp := forall a b c (g : {hom b -> c}) (h : {hom a -> b}),
-    actm [hom g \o h] =1 [hom actm g \o actm h].
+    actm (g \@ h) =m= (actm g \@ actm h).
 End def.
 End FunctorLaws.
 
@@ -327,6 +377,11 @@ Notation "F # f" := (actm F f) : category_scope.
 Notation "{ 'functor' fCD }" := (functor_phant (Phant fCD))
   (format "{ 'functor'  fCD }") : category_scope.
 
+Add Parametric Morphism (C D : category) (F : {functor C -> D}) (A B : C):
+  (@actm C D F A B) with
+    signature (@eq_morphism C B A) ==> (@eq_morphism D (F B) (F A))
+      as functor_mor.
+Proof. exact: functor_ext_hom. Qed.
 
 Record eq_functor (C D : category)
   (F : {functor C -> D}) (G : {functor C -> D}) : Prop := EqFunctor {
@@ -339,22 +394,22 @@ Notation "F =#= G" := (eq_functor F G).
 Section functor_lemmas.
 Variables (C D : category) (F : {functor C -> D}).
 
-Lemma functor_id a : F # [hom idfun] =1 idfun :> (el (F a) -> el (F a)).
+Lemma functor_id a : F # idfun =m= (idfun : {hom F a -> F a}).
 Proof.
-move=> x.
-by rewrite (functor_ext_hom _ _ _ (homfunK _)) functor_id_hom.
+by move=> x; rewrite (functor_ext_hom _ _ _ (homfunK _)) functor_id_hom.
 Qed.
 
 Lemma functor_o a b c (g : {hom b -> c}) (h : {hom a -> b}) :
-  F # [hom g \o h] =1 F # g \o F # h :> (el (F a) -> el (F c)).
+  F # (g \@ h) =m= F # g \@ F # h.
 Proof. by move=> fa; rewrite functor_comp_hom. Qed.
 
 Lemma functor_ext (G : {functor C -> D}) (eq : F =1 G) :
   (forall (A B : C) (f : {hom A -> B}),
-      transport_hom (eq A) (eq B) (F # f) =1 G # f) -> F =#= G.
+      transport_hom (eq A) (eq B) (F # f) =m= G # f) -> F =#= G.
 Proof. exact: EqFunctor. Qed.
 
 End functor_lemmas.
+Arguments functor_o [C D] F.
 
 
 Section functor_equality.
@@ -370,7 +425,7 @@ Proof.
 move=> [pmFG eqFG] [pmGH eqGH].
 apply: (functor_ext (eq := fun A => eq_trans (pmFG A) (pmGH A))) => A B f x.
 rewrite -transport_hom_trans -eqGH /=.
-exact: transport_homE.
+exact/transport_homE/eqFG.
 Qed.
 
 Lemma eq_functor_sym (F G : {functor C -> D}) : F =#= G -> G =#= F.
@@ -383,6 +438,12 @@ move: (G # f) => {f}.
 by case:_/(pm B); case:_/(pm A).
 Qed.
 
+Add Parametric Relation : {functor C -> D} (@eq_functor C D)
+    reflexivity proved by eq_functor_refl
+    symmetry proved by  eq_functor_sym
+    transitivity proved by eq_functor_trans
+    as eq_functor_equiv.
+
 End functor_equality.
 
 
@@ -394,8 +455,8 @@ Variable C D : category.
 Lemma functor_o_head (a b c : C)
   (g : {hom b -> c}) (h : {hom a -> b}) d (F : {functor C -> D})
     (k : {hom d -> F a}) :
-  (F # [hom g \o h]) \o k =1 [\o F # g, F # h, k].
-Proof. by move=> x /=; rewrite functor_comp_hom. Qed.
+  (F # (g \@ h)) \@ k =m= [\@ F # g, F # h, k].
+Proof. by rewrite functor_comp_hom. Qed.
 
 End functor_o_head.
 Arguments functor_o_head [C D a b c g h d] F.
@@ -477,21 +538,15 @@ Variables (C D : category) (a b : C) (h : {isom a -> b}) (F : {functor C -> D}).
 
 Let hom := F # h : _ -> _.
 HB.instance Definition _ := Hom.on hom.
-Let inv := F # inv_hom h.
-Fact functor_homK : cancel hom inv.
-Proof.
-move=> x; rewrite -[LHS]compapp -functor_o.
-have hK : inv_hom h \o h =1 idfun by apply: homK.
-by rewrite (functor_ext_hom F _ _ hK) functor_id.
-Qed.
-Fact functor_inv_homK : cancel inv hom.
-Proof.
-move=> x; rewrite -[LHS]compapp -functor_o.
-have hK : h \o inv_hom h =1 idfun by apply: inv_homK.
-by rewrite (functor_ext_hom F _ _ hK) functor_id.
-Qed.
+Local Lemma homE : hom =m= F # h.
+Proof. by []. Qed.
+Fact functor_homK : F # (inv_hom h) \@ hom =m= idfun.
+Proof. by rewrite homE -functor_o isomK functor_id. Qed.
+Fact functor_inv_homK : hom \@ F # (inv_hom h) =m= idfun.
+Proof. by rewrite homE -functor_o isom_invK functor_id. Qed.
+
 HB.instance Definition _ :=
-  isIsom.Build _ _ _ hom (isHom_inhom inv) functor_homK functor_inv_homK.
+  hasInverse.Build D (F a) (F b) hom functor_homK functor_inv_homK.
 
 Lemma functor_inv_homE : inv_hom hom = F # (inv_hom h).
 Proof. by []. Qed.
@@ -501,7 +556,7 @@ End functor_inv_hom.
 
 Notation "F ~~> G" := (forall a, {hom F a -> G a}) : category_scope.
 Definition naturality (C D : category) (F G : {functor C -> D}) (f : F ~~> G) :=
-  forall (a b : C) (h : {hom a -> b}), (G # h) \o (f a) =1 (f b) \o (F # h).
+  forall (a b : C) (h : {hom a -> b}), (G # h) \@ (f a) =m= (f b) \@ (F # h).
 Arguments naturality [C D].
 HB.mixin Record isNatural
     (C D : category) (F G : {functor C -> D}) (f : F ~~> G) :=
@@ -519,15 +574,10 @@ Import comps_notation.
 Variables (C D : category) (F G : {functor C -> D}).
 
 Lemma natural_head (phi : F ~> G) a b c (h : {hom a -> b}) (f : {hom c -> F a}) :
-  [\o G # h, phi a, f] =1 [\o phi b, F # h, f].
-Proof.
-move=> x; rewrite -!hom_compA /=.
-case: phi => [t [[]]] /=; rewrite /naturality /= => nat_t.
-exact: nat_t a b h (f x).
-Qed.
+  [\@ G # h, phi a, f] =m= [\@ phi b, F # h, f].
+Proof. by rewrite -!hom_compA (natural phi). Qed.
 
-Definition eq_nattrans (phi psi : F ~> G) :=
-  forall a : C, (phi a =1 psi a :> (_ -> _)).
+Definition eq_nattrans (phi psi : F ~> G) := forall a : C, (phi a =m= psi a).
 Notation "p =%= q" := (eq_nattrans p q).
 
 Lemma eq_nattrans_refl (phi : F ~> G) : phi =%= phi.
@@ -537,6 +587,12 @@ Proof. by move=> eq a x /[!eq]. Qed.
 Lemma eq_nattrans_trans (phi psi ksi : F ~> G) :
   phi =%= psi -> psi =%= ksi -> phi =%= ksi.
 Proof. by move=> eqp eqk a x /[!eqp] /[!eqk]. Qed.
+
+Add Parametric Relation : (F ~> G) eq_nattrans
+    reflexivity proved by eq_nattrans_refl
+    symmetry proved by  eq_nattrans_sym
+    transitivity proved by eq_nattrans_trans
+    as eq_nattrans_equiv.
 
 End natural_transformation_lemmas.
 Arguments natural_head [C D F G].
@@ -564,16 +620,13 @@ Variables (C D : category) (F G : {functor C -> D}).
 Variable (Iobj : forall c, F c = G c).
 Local Notation tc := (transport_codom (Iobj _)).
 Local Notation td := (transport_dom (esym (Iobj _))).
-Variable (Imor : forall a b (f : {hom a -> b}), tc (F # f) =1 td (G # f)).
+Variable (Imor : forall a b (f : {hom a -> b}), tc (F # f) =m= td (G # f)).
 (* tc (F # f) and td (G # f) : {hom F a -> G b}) *)
 Definition f : F ~~> G := fun (c : C) => tc [hom idfun].
 
 Fact natural : naturality F G f.
 Proof.
-move=> a b h x.
-rewrite /f /= 2!transport_codomF 2!homcompE 2!compfid.
-rewrite !hom_compE -[RHS]transport_codomF.
-by rewrite Imor transport_domF homfunK /= esymK.
+by move=> a b h; rewrite -transport_codomF Imor transport_domF esymK.
 Qed.
 HB.instance Definition _ := isNatural.Build C D F G f natural.
 Definition n : F ~> G := [the _ ~> _ of f].
@@ -609,10 +662,12 @@ Section vertical_composition.
 
 Variables (C D : category) (F G H : {functor C -> D}).
 Variables (g : G ~> H) (f : F ~> G).
-Definition vcomp := fun a => [hom g a \o f a].
+Definition vcomp := fun a => g a \@ f a.
 
 Fact natural_vcomp : naturality _ _ vcomp.
-Proof. by move=> A B h x; rewrite (natural_head g) compapp (natural f). Qed.
+Proof.
+by rewrite /vcomp => A B h; rewrite -homcompA natural homcompA natural.
+Qed.
 HB.instance Definition _ := isNatural.Build C D F H
   vcomp natural_vcomp.
 Definition VComp : F ~> H := [the F ~> H of vcomp].
@@ -632,9 +687,9 @@ Lemma VIdComp : NId G \v f =%= f.
 Proof. by []. Qed.
 Lemma VCompA : (h \v g) \v f =%= h \v (g \v f).
 Proof. by []. Qed.
-Lemma VCompE_nat : g \v f = (fun a => [hom g a \o f a]) :> (_ ~~> _).
+Lemma VCompE_nat : g \v f = (fun a => g a \@ f a) :> (_ ~~> _).
 Proof. by []. Qed.
-Lemma VCompE a : (g \v f) a = g a \o f a :> (_ -> _).
+Lemma VCompE a : (g \v f) a = g a \@ f a.
 Proof. by []. Qed.
 
 End vcomp_lemmas.
@@ -645,14 +700,12 @@ Section horizontal_composition.
 Variables (C D E : category) (F G : {functor C -> D}) (F' G' : {functor D -> E}).
 Variables (s : F ~> G) (t : F' ~> G').
 Definition hcomp : F' \O F ~~> G' \O G :=
-  fun (c : C) => [hom t (G c) \o F' # s c].
+  fun (c : C) => t (G c) \@ F' # s c.
 
 Fact natural_hcomp : naturality (F' \O F) (G' \O G) hcomp.
 Proof.
-move=> c0 c1 h x; rewrite [in LHS]compA [LHS](natural t).
-rewrite !hom_compE -[in LHS]compA -[in RHS]compA; apply: eq_comp => // {}x.
-rewrite [in RHS]FCompE -2!functor_o; apply: functor_ext_hom => {}x.
-by rewrite /= !hom_compE natural.
+rewrite /hcomp => c0 c1 h /=.
+by rewrite !FCompE -!homcompA (natural t) !homcompA -!functor_o (natural s).
 Qed.
 HB.instance Definition _ := isNatural.Build C E (F' \O F) (G' \O G)
   hcomp natural_hcomp.
@@ -668,10 +721,10 @@ Variables (C D E : category) (F G : {functor C -> D}) (F' G' : {functor D -> E})
 Variables (s : F ~> G) (t : F' ~> G').
 
 Lemma HCompE_def : t \h s = HComp s t. Proof. by unlock. Qed.
-Lemma HCompE c : (t \h s) c = t (G c) \o F' # s c :> (_ -> _).
+Lemma HCompE c : (t \h s) c =m= t (G c) \@ F' # s c.
 Proof. by unlock. Qed.
-Lemma HCompE_alt c : (t \h s) c =1 G' # (s c) \o t (F c) :> (_ -> _).
-Proof. by move=> x; rewrite HCompE natural. Qed.
+Lemma HCompE_alt c : (t \h s) c =m= G' # (s c) \@ t (F c).
+Proof. by rewrite HCompE natural. Qed.
 
 End hcomp_extensionality_lemmas.
 
@@ -686,16 +739,12 @@ Variables
   (F'' G'' : {functor E -> Z}).
 Variables (s : F ~> G) (t : F' ~> G') (u : F'' ~> G'').
 
-Lemma HCompId c : (t \h NId F) c =1 t (F c).
-Proof. by move=> x; rewrite HCompE NIdE /= functor_id. Qed.
-Lemma HIdComp c : (NId G' \h s) c =1 G' # s c.
-Proof. by move=> x; rewrite HCompE NIdE. Qed.
-Lemma HCompA c : ((u \h t) \h s) c =1 (u \h (t \h s)) c.
-Proof.
-move=> x; rewrite [in LHS]HCompE [in RHS]HCompE [in LHS]HCompE.
-rewrite hom_compA /= (hom_compE _ _ x) -functor_o; apply: eq_comp => // {x}.
-by apply: functor_ext_hom; rewrite HCompE.
-Qed.
+Lemma HCompId c : (t \h NId F) c =m= t (F c).
+Proof. by rewrite HCompE NIdE functor_id. Qed.
+Lemma HIdComp c : (NId G' \h s) c =m= G' # s c.
+Proof. by rewrite HCompE NIdE. Qed.
+Lemma HCompA c : ((u \h t) \h s) c =m= (u \h (t \h s)) c.
+Proof. by rewrite !HCompE homcompA -!functor_o. Qed.
 
 End hcomp_id_assoc_lemmas.
 
@@ -709,16 +758,13 @@ Variables (s : F ~> G) (t : F' ~> G').
 (* higher level horizontal composition is a vertical composition of
    horizontal compositions *)
 Lemma HComp_VH : t \h s =%= (t \h NId G) \v (NId F' \h s).
-Proof. by move=> a x; rewrite VCompE HCompE /= HIdComp HCompId. Qed.
+Proof. by move=> a; rewrite VCompE HCompE /= HIdComp HCompId. Qed.
 Lemma HComp_VH_aux : t \h s =%= (NId G' \h s) \v (t \h NId F).
-Proof.
-move=> a x; rewrite VCompE HCompE /= HIdComp HCompId.
-by rewrite hom_compE -natural.
-Qed.
+Proof. by move=> a; rewrite VCompE HCompE /= HIdComp HCompId natural. Qed.
 Lemma NIdFId c : NId (@FId C) c = [hom idfun].
 Proof. by []. Qed.
 Lemma NIdFComp : NId (F' \O F) =%= NId F' \h NId F.
-Proof. by move=> c; rewrite HCompE /= compidf => x; rewrite functor_id. Qed.
+Proof. by move=> c; rewrite HCompE /= hom_Idcomp functor_id. Qed.
 
 (* horizontal and vertical compositions interchange *)
 Variables (H : {functor C -> D}) (H' : {functor D -> E}).
@@ -726,10 +772,8 @@ Variables (s' : G ~> H) (t' : G' ~> H').
 
 Lemma HCompACA : (t' \h s') \v (t \h s) =%= (t' \v t) \h (s' \v s).
 Proof.
-move=> c /= x.
-rewrite !HCompE !VCompE -compA -[in RHS]compA.
-apply: eq_comp => // {}x; rewrite natural_head /=.
-by rewrite (hom_compE _ _ x) -functor_o.
+move=> c; rewrite !(HCompE, VCompE) !homcompA.
+by rewrite -(natural t _ (H c)) functor_o homcompA natural.
 Qed.
 
 End hcomp_lemmas.
@@ -837,10 +881,10 @@ Proof.
 move=> x; rewrite /fun_eqGFId /fun_eqIdGF /= homK !HCompId !HIdComp.
 by rewrite -functor_inv_homE homK.
 Qed.
-Fact fun_eqIdGFK (c : C) : cancel (trans_eqIdGF c) (trans_eqGFId c).
+Fact fun_eqIdGFK (c : C) : cancel (@fun_eqIdGF c) (@fun_eqGFId c).
 Proof.
 move=> x; rewrite /fun_eqGFId /fun_eqIdGF /= !HCompId !HIdComp.
-by rewrite -functor_inv_homE !inv_homK.
+by rewrite -functor_inv_homE FCompE FIdf /= !inv_homK.
 Qed.
 HB.instance Definition _ (c : C) := Hom.on (@fun_eqGFId c).
 HB.instance Definition _ (c : C) :=
@@ -875,8 +919,8 @@ Module TriangularLaws.
 Section triangularlaws.
 Variables (C D : category) (F : {functor C -> D}) (G : {functor D -> C}).
 Variables (eta : FId ~> G \O F) (eps : F \O G ~> FId).
-Definition left := forall c, eps (F c) \o F # (eta c) =1 idfun.
-Definition right := forall d, G # (eps d) \o eta (G d) =1 idfun.
+Definition left := forall c, eps (F c) \@ F # (eta c) =m= idfun.
+Definition right := forall d, G # (eps d) \@ eta (G d) =m= idfun.
 End triangularlaws.
 End TriangularLaws.
 
@@ -896,45 +940,39 @@ Variables (C D : category) (F : {functor C -> D}) (G : {functor D -> C}).
 Variable A : F -| G.
 
 Definition hom_iso c d : {hom F c -> d} -> {hom c -> G d} :=
-  fun h => [hom (G # h) \o (eta A c)].
+  fun h => (G # h) \@ (eta A c).
 
 Definition hom_inv c d : {hom c -> G d} -> {hom F c -> d} :=
-  fun h => [hom (eps A d) \o (F # h)].
+  fun h => (eps A d) \@ (F # h).
 
 Import comps_notation.
 
-Lemma hom_isoK (c : C) (d : D) (f : {hom F c -> d}) : hom_inv (hom_iso f) =1 f.
+Lemma hom_isoK (c : C) (d : D) (f : {hom F c -> d}) :
+  hom_inv (hom_iso f) =m= f.
 Proof.
-rewrite /hom_inv /hom_iso => x.
-rewrite /= functor_o -[LHS](natural_head (eps A)).
-by rewrite compapp triL.
+rewrite /hom_inv /hom_iso /= functor_o -!FCompE -homcompA /=.
+by rewrite -(natural (eps A)) homcompA triL.
 Qed.
-Lemma hom_invK (c : C) (d : D) (g : {hom c -> G d}) : hom_iso (hom_inv g) =1 g.
+Lemma hom_invK (c : C) (d : D) (g : {hom c -> G d}) :
+  hom_iso (hom_inv g) =m= g.
 Proof.
-rewrite /hom_inv /hom_iso => x.
-rewrite /= functor_o.
-rewrite !hom_compE hom_compA compapp (natural (eta A)).
-by rewrite !(hom_compE _ _ x) -hom_compA compapp triR.
+rewrite /hom_inv /hom_iso /= functor_o -!FCompE homcompA /=.
+by rewrite (natural (eta A)) -homcompA triR.
 Qed.
-
 Lemma hom_iso_inj (c : C) (d : D) (f g : {hom F c -> d}) :
-  hom_iso f =1 hom_iso g -> f =1 g.
+  hom_iso f =m= hom_iso g -> f =m= g.
 Proof.
-move=> eq x.
-rewrite -[LHS]hom_isoK -[RHS]hom_isoK /=.
-by rewrite (functor_ext_hom F _ _ eq).
+by move=> eq; rewrite -(hom_isoK f) -(hom_isoK g) /hom_inv eq.
 Qed.
 Lemma hom_inv_inj (c : C) (d : D) (f g : {hom c -> G d}) :
-  hom_inv f =1 hom_inv g -> f =1 g.
+  hom_inv f =m= hom_inv g -> f =m= g.
 Proof.
-move=> eq x.
-rewrite -[LHS]hom_invK -[RHS]hom_invK /=.
-by rewrite (functor_ext_hom G _ _ eq).
+by move=> eq; rewrite -(hom_invK f) -(hom_invK g) /hom_iso eq.
 Qed.
 
-Lemma eta_hom_iso (c : C) : eta A c =1 hom_iso [hom idfun].
+Lemma eta_hom_iso (c : C) : eta A c =m= hom_iso idfun.
 Proof. by rewrite /hom_iso => x /=; rewrite functor_id. Qed.
-Lemma eps_hom_inv (d : D) : eps A d =1 hom_inv [hom idfun].
+Lemma eps_hom_inv (d : D) : eps A d =m= hom_inv idfun.
 Proof. by rewrite /hom_iso => x /=; rewrite functor_id. Qed.
 
 (*
@@ -983,9 +1021,9 @@ Definition Eta : FId ~> G \O F :=
     \v (NId G0 \h eta1 \h NId F0)
     \v [NEq G0 \O F0 , G0 \O FId \O F0]
     \v eta0.
-Lemma EtaE a : Eta a =1 G0 # (eta1 (F0 a)) \o (eta0 a).
+Lemma EtaE a : Eta a =m= G0 # (eta1 (F0 a)) \@ (eta0 a).
 Proof. by move=> x /=; rewrite HCompId HIdComp. Qed.
-Lemma EtaE_hom a : Eta a =1 [hom G0 # (eta1 (F0 a)) \o (eta0 a)].
+Lemma EtaE_hom a : Eta a =m= G0 # (eta1 (F0 a)) \@ (eta0 a).
 Proof. by move=> x; rewrite EtaE. Qed.
 
 Definition Eps : F \O G ~> FId :=
@@ -993,46 +1031,38 @@ Definition Eps : F \O G ~> FId :=
     \v [NEq F1 \O FId \O G1 , F1 \O G1]
     \v (NId F1 \h eps0 \h NId G1)
     \v [NEq F \O G , (F1 \O (F0 \O G0)) \O G1].
-Lemma EpsE a : Eps a =1 (eps1 _) \o F1 # (eps0 (G1 a)) :> (_ -> _).
+Lemma EpsE a : Eps a =m= (eps1 _) \@ F1 # (eps0 (G1 a)).
 Proof. by move=> x /=; rewrite HCompId HIdComp. Qed.
-Lemma EpsE_hom a : Eps a =1 [hom (eps1 _) \o F1 # (eps0 (G1 a))].
+Lemma EpsE_hom a : Eps a =m= (eps1 _) \@ F1 # (eps0 (G1 a)).
 Proof. by move=> x; rewrite EpsE. Qed.
 
 Lemma triL : TriangularLaws.left Eta Eps.
 Proof.
-move=> c x.
-rewrite [RHS]/= [LHS]EpsE (functor_ext_hom _ _ _ (@EtaE_hom c)).
-rewrite (hom_compE _ _ x) hom_compA /= (functor_o (F := F)) /F /=.
-rewrite 2!(hom_compE _ _ x) -(functor_o_head F1).
-set X := [hom [\o _, _]].
-have /= -> : F1 # X =1 F1 # ((FId # eta1 (F0 c)) \o (eps0 (F0 c))).
-  by move=> y; apply functor_ext_hom => {}y /=; rewrite -[LHS](natural eps0).
-  rewrite (hom_compE _ _ x) (functor_o_head F1) FIdf.
-have /= -> := triL1 (_ (_ x)).
-rewrite -[RHS]/(idfun x) -[in RHS](functor_id (F := F1)).
-rewrite -[LHS]functor_o; apply functor_ext_hom => /= {}x.
-by rewrite triL0.
+move=> c; rewrite EpsE EtaE_hom homcompA (functor_o F) /F.
+rewrite -(functor_o_head F1).
+set X := (X in F1 # X).
+evar (TY : Type).
+evar (Y : TY).
+have -> : X =m= Y by rewrite /X -(natural eps0) => x; apply: erefl.
+rewrite (functor_o_head F1) FIdf.
+rewrite -!hom_compA triL1 hom_Idcomp.
+by rewrite -(functor_o F1) triL0 functor_id.
 Qed.
 
 (* [\o eps (F c), F # eta c] =1 idfun *)
 Lemma triR : TriangularLaws.right Eta Eps.
 Proof.
-move=> c x.
-have := functor_ext_hom _ _ _ (EpsE_hom (a := c)) (Eta (G c) x).
-rewrite (hom_compE _ _ x) => ->; rewrite EtaE.
-rewrite (hom_compE _ _ x) (functor_o_head G).
-rewrite /= 2!(hom_compE _ _ x) -(functor_o_head G0).
-rewrite !(hom_compE _ _ x).
+move=> c.
+rewrite EpsE_hom EtaE (functor_o_head G) -(functor_o_head G0 (eta0 _)).
+(* FRAGILE!
+   simpl here breaks the notation and renders the following set X impossible *)
 set X := (X in G0 # X).
-have /= -> : G0 # X =1 G0 # [\o eta1 (G1 c), FId # eps0 (G1 c)].
-  move => {}x; apply functor_ext_hom => {}x; rewrite /X /=.
-  by rewrite !(hom_compE _ _ x) (natural eta1). 
-rewrite (functor_o (F := G0)) (hom_compE _ _ x) hom_compA FIdf.
-have /= -> := triR0 (_ x).
-rewrite -[RHS]/(idfun x) -[in RHS](functor_id (F := G0)).
-rewrite -[LHS](functor_o (F := G0)).
-apply functor_ext_hom => {x} /= x.
-by rewrite triR1.
+evar (TY : Type).
+evar (Y : TY).
+have -> : G0 # X =m= G0 # Y
+  by rewrite /X /= (natural eta1) => x; exact: erefl.
+rewrite (functor_o G0) hom_compA FIdf triR0 hom_compId.
+by rewrite -(functor_o G0) triR1 functor_id.
 Qed.
 
 End def.
@@ -1066,32 +1096,26 @@ Definition eta := (GG'\h NId F) \v (AdjointFunctors.eta adj).
 
 Fact triL : TriangularLaws.left eta eps.
 Proof.
-rewrite /eps /eta => A a.
-have:= AdjointFunctors.triL adj a.
+rewrite /eps /eta => A.
+have:= AdjointFunctors.triL adj.
 move: (AdjointFunctors.eps adj) => eps.
 move: (AdjointFunctors.eta adj) => eta <-.
-rewrite !VCompE !compapp; congr (eps (F A) _).
-rewrite HIdComp -[LHS]compapp -functor_o.
-move: a; apply: functor_ext_hom => a /=.
-by rewrite !HCompId /= GG'K.
+rewrite !VCompE homcompA HIdComp /= -functor_o.
+rewrite HCompId -homcompA.
+have -> : G'G (F A) \@ GG' (F A) =m= idfun by move=> x /=; rewrite GG'K.
+by rewrite functor_o functor_id hom_Idcomp.
 Qed.
 
 Fact triR : TriangularLaws.right eta eps.
 Proof.
-rewrite /eps /eta => A a.
-rewrite !(HIdComp, HCompId, VCompE, compapp).
-have:= AdjointFunctors.triR adj (G'G A a).
+rewrite /eps /eta => A.
+have:= AdjointFunctors.triR adj.
 move: (AdjointFunctors.eps adj) => eps.
-move: (AdjointFunctors.eta adj) => eta /(congr1 (GG' A)).
-rewrite !idfunE G'GK => {2}<-.
-rewrite !(HIdComp, HCompId, VCompE, compapp).
-have := natural eta _ (G A) (G'G A) a.
-rewrite FIdf !compapp => <-; move: (eta (G' A) a) => {}a.
-rewrite -[RHS]compapp -(natural GG' _ A (eps A)).
-rewrite VCompE_nat functor_o !compapp /=; congr ((G' # eps A) _).
-rewrite -[LHS]compapp (natural GG') /= ; congr (GG' _ _).
-rewrite FCompE HCompE_def /HComp /= /hcomp /=.
-by rewrite functor_o /= NIdE functor_id_hom.
+move: (AdjointFunctors.eta adj) => eta triR.
+rewrite !(HIdComp, HCompId, VCompE) /= functor_o !homcompA.
+rewrite (natural_head GG' (F (G' A))) -FCompE (natural eta) FIdf.
+rewrite (natural_head GG') -(homcompA (G # _)) triR.
+by rewrite hom_Idcomp => x /=; rewrite G'GK.
 Qed.
 
 End adjNatIsom.
@@ -1114,40 +1138,33 @@ End Adjoint_NatIsom.
 Export Adjoint_NatIsom.Exports.
 
 
-Module MonadLaws.
-Section monad_laws.
-
+Module JoinLaws.
+Section join_laws.
 Variables (C : category) (M : {functor C -> C}) .
-Variables (unit : FId ~~> M) (mu : M \O M ~~> M).
-Definition left_unit :=
-  forall a, mu a \o unit (M a) =1 idfun :> (el (M a) -> el (M a)).
-Definition right_unit :=
-  forall a, mu a \o M # unit a =1 idfun :> (el (M a) -> el (M a)).
+Variables (ret : FId ~~> M) (join : M \O M ~~> M).
+Definition left_unit  := forall a, join a \@ ret (M a) =m= idfun.
+Definition right_unit := forall a, join a \@ M # ret a =m= idfun.
 Definition associativity :=
-  forall a, mu a \o M # mu a =1 mu a \o mu (M a) :>
-                                    (el (M (M (M a))) -> el (M a)).
-End monad_laws.
-End MonadLaws.
-
+  forall a, join a \@ M # join a =m= join a \@ join (M a).
+End join_laws.
+End JoinLaws.
 
 Module BindLaws.
 Section bindlaws.
-
 Variables (C : category) (M : C -> C).
 Variable b : forall A B, {hom A -> M B} -> {hom M A -> M B}.
 Local Notation "m >>= f" := (b f m).
 
 Fact associative_aux x y z (f : {hom x -> M y}) (g : {hom y -> M z}) :
-  (fun w => (f w >>= g)) =1 (b g \o f).
+  (fun w => (f w >>= g)) =1 (b g \@ f).
 Proof. by []. Qed.
 Definition associative :=
   forall A B C (m : el (M A)) (f : {hom A -> M B}) (g : {hom B -> M C}),
-  (m >>= f) >>= g = m >>= [hom b g \o f].
+  (m >>= f) >>= g = m >>= (b g \@ f).
 Definition left_neutral (r : forall A, {hom A -> M A}) :=
-  forall A B (f : {hom A -> M B}), [hom (b f \o r A)] =1 f.
+  forall A B (f : {hom A -> M B}), (b f \@ r A) =m= f.
 Definition right_neutral (r : forall A, {hom A -> M A}) :=
   forall A (m : el (M A)), m >>= r _ = m.
-
 End bindlaws.
 End BindLaws.
 
@@ -1160,28 +1177,28 @@ Local Notation "m >>= f" := (b f m).
 
 Lemma bind_left_neutral_hom_fun (r : forall A, {hom A -> M A})
   : BindLaws.left_neutral b r
-    <-> forall A B (f : {hom A -> M B}), b f \o r A =1 f.
+    <-> forall A B (f : {hom A -> M B}), b f \@ r A =m= f.
 Proof. by split; move=> H A B f; exact: (H A B f). Qed.
 
 End bind_lemmas.
 
 
 HB.mixin Record isMonad (C : category) (M : C -> C) of @Functor C C M := {
-  munit : FId ~> [the {functor C -> C} of M] ;
-  mu : [the {functor C -> C} of M] \O [the {functor C -> C} of M] ~>
+  ret : FId ~> [the {functor C -> C} of M] ;
+  join : [the {functor C -> C} of M] \O [the {functor C -> C} of M] ~>
          [the {functor C -> C} of M] ;
   bind : forall (a b : C), {hom a -> M b} -> {hom M a -> M b} ;
   bind_ext : forall (a b : C) (f g : {hom a -> M b}),
-    f =1 g -> bind a b f =1 bind a b g;
+    f =m= g -> bind a b f =m= bind a b g;
   bindE : forall (a b : C) (f : {hom a -> M b}) (m : el (M a)),
-    bind a b f m = mu b (([the {functor C -> C} of M] # f) m) ;
-  mumunitM : MonadLaws.left_unit munit mu ;
-  muMmunit : MonadLaws.right_unit munit mu ;
-  muA : MonadLaws.associativity mu
+    bind a b f m = join b (([the {functor C -> C} of M] # f) m) ;
+  joinretM : JoinLaws.left_unit ret join ;
+  joinMret : JoinLaws.right_unit ret join ;
+  joinA : JoinLaws.associativity join
 }.
 #[short(type=monad)]
 HB.structure Definition Monad (C : category) :=
-  {M of isMonad C M & @Functor C C M}.
+  {M of isMonad C M & isFunctor C C M}.
 Arguments bind {C M a b} : rename, simpl never.
 Notation "m >>= f" := (bind f m).
 
@@ -1192,123 +1209,129 @@ Variable (C : category) (M : monad C).
 (* *_head lemmas are for [fun of f] \o ([fun of g] \o ([fun of h] \o ..))*)
 
 Import comps_notation.
-Lemma mumunitM_head a (c : C) (f : {hom c -> M a}) : [\o mu _, munit _, f] =1 f.
-Proof.
-by move=> x; rewrite compA (compapp _ (mu a \o munit (M a))) mumunitM.
-Qed.
-Lemma muMmunit_head a (c : C) (f : {hom c -> M a}) : [\o mu _, M # munit _, f] =1 f.
-Proof.
-by move=> x; rewrite compA (compapp _ (mu a \o M # munit a)) muMmunit.
-Qed.
-Lemma muA_head a (c : C) (f : {hom c -> M (M (M a))}) :
-  [\o mu _, M # mu _, f] =1 [\o mu _, mu _, f].
-Proof. by move=> x; rewrite compA compapp muA. Qed.
+(* *_head lemmas are for [fun of f] \o ([fun of g] \o ([fun of h] \o ..))*)
+Import comps_notation.
+Lemma joinretM_head a (c : C) (f : {hom c -> M a}) :
+  [\@ join _, ret _, f] =m= f.
+Proof. by rewrite -homcompA joinretM. Qed.
+Lemma joinMret_head a (c : C) (f : {hom c -> M a}) :
+  [\@ join _, M # ret _, f] =m= f.
+Proof. by rewrite -homcompA joinMret. Qed.
+Lemma joinA_head a (c : C) (f : {hom c -> M (M (M a))}) :
+  [\@ join _, M # join _, f] =m= [\@ join _, join _, f].
+Proof. by rewrite -homcompA joinA. Qed.
 
 End monad_interface.
 
 
-HB.factory Record Monad_of_munit_mu (C : category) (M : C -> C)
+HB.factory Record Monad_of_ret_join (C : category) (M : C -> C)
            of @Functor C C M := {
-  munit : FId ~> [the {functor C -> C} of M] ;
-  mu : M \O M ~> [the {functor C -> C} of M] ;
-  mumunitM : MonadLaws.left_unit munit mu ;
-  muMmunit : MonadLaws.right_unit munit mu ;
-  muA : MonadLaws.associativity mu
+  ret : FId ~> [the {functor C -> C} of M] ;
+  join : M \O M ~> [the {functor C -> C} of M] ;
+  joinretM : JoinLaws.left_unit ret join ;
+  joinMret : JoinLaws.right_unit ret join ;
+  joinA : JoinLaws.associativity join
 }.
-HB.builders Context C M of Monad_of_munit_mu C M.
+HB.builders Context C M of Monad_of_ret_join C M.
 Let F := [the {functor _ -> _} of M].
-Let bind (a b : C) (f : {hom a -> M b}) : {hom M a -> M b} := [hom mu _ \o (F # f)].
+Let bind (a b : C) (f : {hom a -> M b}) : {hom M a -> M b} :=
+      join _ \@ (F # f).
 Let bind_ext (a b : C) (f g : {hom a -> M b}) :
-  f =1 g -> bind f =1 bind g.
+  f =m= g -> bind f =m= bind g.
 Proof. by rewrite /bind => eq x /=; rewrite (functor_ext_hom _ _ _ eq). Qed.
 Let bindE (a b : C) (f : {hom a -> M b}) (m : el (M a)) :
-    bind f m = mu b (([the {functor C -> C} of M] # f) m).
+    bind f m = join b (([the {functor C -> C} of M] # f) m).
 Proof. by []. Qed.
 HB.instance Definition _ :=
-  isMonad.Build C M bind_ext bindE mumunitM muMmunit muA.
+  isMonad.Build C M bind_ext bindE joinretM joinMret joinA.
 HB.end.
 
 
 (* Monads defined by ret and bind; M need not be a priori a functor *)
 HB.factory Record Monad_of_ret_bind (C : category) (acto : C -> C) := {
-  ret : forall a, {hom a -> acto a} ;
+  ret' : forall a, {hom a -> acto a} ;
   bind : forall (a b : C), {hom a -> acto b} -> {hom acto a -> acto b} ;
   bind_ext_hom : forall (a b : C) (f g : {hom a -> acto b}),
-    f =1 g -> bind a b f =1 bind a b g;
-  bindmunitf : BindLaws.left_neutral bind ret ;
-  bindmmunit : BindLaws.right_neutral bind ret ;
+    f =m= g -> bind a b f =m= bind a b g;
+  bindretf : BindLaws.left_neutral bind ret' ;
+  bindmret : BindLaws.right_neutral bind ret' ;
   bindA : BindLaws.associative bind ;
 }.
 HB.builders Context C M of Monad_of_ret_bind C M.
-Let fmap a b (f : {hom a -> b}) := bind [hom ret b \o f].
-Let bindmunitf_fun : (forall (a b : C) (f : {hom a -> M b}),
-  bind f \o ret a =1 f).
-Proof. by apply/bind_left_neutral_hom_fun/bindmunitf. Qed.
+Let fmap a b (f : {hom a -> b}) := bind [hom ret' b \o f].
+Let bindretf_fun : (forall (a b : C) (f : {hom a -> M b}),
+  bind f \@ ret' a =m= f).
+Proof. by apply/bind_left_neutral_hom_fun/bindretf. Qed.
+Let fmap_id : FunctorLaws.id fmap.
+Proof.
+move=> A m; rewrite /fmap /idfun -[in RHS](bindmret m).
+by apply: bind_ext_hom.
+Qed.
 Let fmap_ext : FunctorLaws.ext fmap.
 Proof.
 by move=> A B f g eq; rewrite /fmap; apply: bind_ext_hom => x /= /[!eq].
-Qed.
-Let fmap_id : FunctorLaws.id fmap.
-Proof.
-move=> A m; rewrite /fmap; rewrite /idfun.
-rewrite -[in RHS](bindmmunit m).
-by apply: bind_ext_hom => x.
 Qed.
 Let fmap_o : FunctorLaws.comp fmap.
 Proof.
 move=> a b c g h x; rewrite /fmap.
 rewrite [RHS]bindA/=; apply: bind_ext_hom => {}x /=.
-by rewrite -[RHS]compapp bindmunitf_fun.
+rewrite !hom_compE homcompA; apply: esym.
+exact: bindretf_fun.
 Qed.
 HB.instance Definition _ := isFunctor.Build C C M fmap_ext fmap_id fmap_o.
 Notation F := [the {functor _ -> _} of M].
 
-Let ret_naturality : naturality FId F ret.
-Proof. by move=> A B h x; rewrite FIdf bindmunitf_fun. Qed.
+Let ret'_naturality : naturality FId F ret'.
+Proof. by move=> A B h; rewrite FIdf bindretf_fun. Qed.
 HB.instance Definition _ := isNatural.Build _ _ FId F
-  (ret : FId ~~> M)(*NB: fails without this type constraint*) ret_naturality.
-Definition munit := [the FId ~> F of ret].
-Let mu' : F \O F ~~> F := fun _ => bind [hom idfun].
+  (ret' : FId ~~> M)(*NB: fails without this type constraint*) ret'_naturality.
+Definition ret := [the FId ~> F of ret'].
+Let join' : F \O F ~~> F := fun _ => bind [hom idfun].
 Let fmap_bind a b c (f : {hom a ->b}) m (g : {hom c ->F a}) :
-  (fmap f) (bind g m) = bind [hom fmap f \o g] m.
+  (fmap f) (bind g m) = bind (fmap f \@ g) m.
 Proof. by rewrite /fmap bindA. Qed.
-Let mu'_naturality : naturality (F \O F) F mu'.
+Let join'_naturality : naturality (F \O F) F join'.
 Proof.
-move=> A B h m; rewrite /mu /=.
+move=> A B h m; rewrite /join /=.
 rewrite fmap_bind bindA; apply: bind_ext_hom => {}m /=.
-by rewrite -[RHS]compapp bindmunitf_fun.
+rewrite !hom_compE homcompA; apply: esym.
+exact: bindretf_fun.
 Qed.
-HB.instance Definition _ := isNatural.Build _ _ _ _ _ mu'_naturality.
-Definition mu := [the F \O F ~> F of mu'].
+HB.instance Definition _ := isNatural.Build _ _ _ _ _ join'_naturality.
+Definition join := [the F \O F ~> F of join'].
 
 Let bind_fmap a b c (f : {hom a -> b}) (m : el (F a)) (g : {hom b -> F c}) :
-  bind g (fmap f m) = bind [hom g \o f] m .
+  bind g (fmap f m) = bind (g \@ f) m .
 Proof.
 rewrite bindA /=; apply: bind_ext_hom => {}m /=.
-by rewrite -[LHS]compapp bindmunitf_fun.
+rewrite !hom_compE homcompA /=.
+exact: bindretf_fun.
 Qed.
 Lemma bindE (a b : C) (f : {hom a -> F b}) (m : el (F a)) :
-  bind f m = mu b (([the {functor C -> C} of F] # f) m).
-Proof. by rewrite /mu /= bind_fmap /=; apply: bind_ext_hom. Qed.
-Lemma mumunitM : MonadLaws.left_unit munit mu.
-Proof. by rewrite /mu => A m /=; rewrite -[LHS]compapp bindmunitf_fun. Qed.
-Let bind_fmap_fun a b c (f : {hom a ->b}) (g : {hom b -> F c}) :
-  bind g \o fmap f =1 bind [hom g \o f].
-Proof. by move=> m; exact: bind_fmap. Qed.
-Lemma muMmunit : MonadLaws.right_unit munit mu.
+  bind f m = join b (([the {functor C -> C} of F] # f) m).
+Proof. by rewrite /join /= bind_fmap /=; apply: bind_ext_hom. Qed.
+Lemma joinretM : JoinLaws.left_unit ret join.
 Proof.
-rewrite /mu => A ma /=.
-rewrite -[LHS]compapp bind_fmap_fun/= -[in RHS](bindmmunit ma).
+rewrite /join => A m /=; rewrite !hom_compE.
+exact: bindretf_fun.
+Qed.
+Let bind_fmap_fun a b c (f : {hom a ->b}) (g : {hom b -> F c}) :
+  bind g \@ fmap f =m= bind (g \@ f).
+Proof. by move=> m; exact: bind_fmap. Qed.
+Lemma joinMret : JoinLaws.right_unit ret join.
+Proof.
+rewrite /join => A ma /=; rewrite !hom_compE.
+rewrite bind_fmap_fun/= -[in RHS](bindmret ma) /=.
 exact: bind_ext_hom.
 Qed.
-Lemma muA : MonadLaws.associativity mu.
+Lemma joinA : JoinLaws.associativity join.
 Proof.
-move => A mmma; rewrite /mu.
+move => A mmma; rewrite /join.
 rewrite bind_fmap_fun/= bindA/=.
 exact: bind_ext_hom.
 Qed.
 HB.instance Definition _ :=
-  isMonad.Build C M bind_ext_hom bindE mumunitM muMmunit muA.
+  isMonad.Build C M bind_ext_hom bindE joinretM joinMret joinA.
 HB.end.
 
 
@@ -1322,49 +1345,48 @@ Variable A : F -| G.
 Definition eps := AdjointFunctors.eps A.
 Definition eta := AdjointFunctors.eta A.
 Definition M := G \O F.
-Definition mu : M \O M ~~> M := fun a => G # (eps (F a)).
-Definition munit : FId ~~> M := fun a => eta a.
+Definition join : M \O M ~~> M := fun a => G # (eps (F a)).
+Definition ret : FId ~~> M := fun a => eta a.
 Let triL := AdjointFunctors.triL A.
 Let triR := AdjointFunctors.triR A.
 
-Lemma naturality_munit : naturality FId M munit.
+Lemma naturality_ret : naturality FId M ret.
 Proof. by move=> a b f x; rewrite (natural eta). Qed.
-HB.instance Definition _ := isNatural.Build C C FId M munit naturality_munit.
-Lemma naturality_mu : naturality (M \O M) M mu.
+HB.instance Definition _ := isNatural.Build C C FId M ret naturality_ret.
+Lemma naturality_join : naturality (M \O M) M join.
 Proof.
-rewrite /mu => a b h x.
+rewrite /join => a b h x.
 rewrite /M !FCompE -2!(@functor_o _ _ G) /=; apply: functor_ext_hom => {}x.
 exact: (natural eps).
 Qed.
-HB.instance Definition _ := isNatural.Build C C (M \O M) M mu naturality_mu.
+HB.instance Definition _ := isNatural.Build C C (M \O M) M join naturality_join.
 
-Let muE : mu = fun a => G # (@eps (F a)).
+Let joinE : join = fun a => G # (@eps (F a)).
 Proof. by []. Qed.
-Let mu_associativity' a : mu a \o mu (M a) =1 mu a \o (M # mu a).
+Let join_associativity' a : join a \@ join (M a) =m= join a \@ (M # join a).
 Proof.
-move=> x; rewrite muE -2!(@functor_o _ _ G) /=; apply: functor_ext_hom => {}x /=.
+move=> x; rewrite joinE -2!(@functor_o _ _ G) /=; apply: functor_ext_hom => {}x /=.
 exact: (natural eps).
 Qed.
-Lemma mu_associativity : MonadLaws.associativity mu.
-Proof. by move=> a x; rewrite mu_associativity'. Qed.
-Lemma mu_left_unit : MonadLaws.left_unit munit mu.
-Proof. by move=> a x; rewrite muE triR. Qed.
-Lemma mu_right_unit : MonadLaws.right_unit munit mu.
+Lemma join_associativity : JoinLaws.associativity join.
+Proof. by move=> a x; rewrite join_associativity'. Qed.
+Lemma join_left_unit : JoinLaws.left_unit ret join.
+Proof. by move=> a x; rewrite joinE triR. Qed.
+Lemma join_right_unit :JoinLaws.right_unit ret join.
 Proof.
-move=> a x; rewrite muE /M FCompE /=.
-rewrite -[LHS](@functor_o _ _ G) -[RHS](@functor_id _ _ G).
-apply: functor_ext_hom => {}x; exact: triL.
+move=> a; rewrite joinE /M FCompE /=.
+by rewrite -(functor_o G) triL functor_id.
 Qed.
 
 HB.instance Definition _ :=
-  Monad_of_munit_mu.Build C (G \o F) mu_left_unit mu_right_unit mu_associativity.
+  Monad_of_ret_join.Build C (G \o F) join_left_unit join_right_unit join_associativity.
 
 End def.
 
 
 Definition build (C D : category)
            (F : {functor C -> D}) (G : {functor D -> C}) (A : F -| G) :=
-  Monad.Pack (Monad.Class (category_Monad_of_munit_mu__to__category_isMonad A)).
+  Monad.Pack (Monad.Class (category_Monad_of_ret_join__to__category_isMonad A)).
 
 End _Monad_of_adjoint_functors.
 Notation Monad_of_adjoint_functors := _Monad_of_adjoint_functors.build.


### PR DESCRIPTION
Attempt to use setoid rewrite to solve
- Support for some setoid rewrite in particular for =1 and \o would be super useful. For example, the following computation is currently very tedious: suppose that you now that f =1 idfun where f is a morphism {hom a -> b} in some category. Recall that F # f is the application of the functor F to f. Then this should be three rewrites F # f \o h =1 F # idfun \o h =1 idfun \o h =1 h. Currently lot's of time is spend in precisely folding and unfolding map compositions. 